### PR TITLE
Fix: use JBCOM_DEPLOY_TOKEN for sync

### DIFF
--- a/.github/workflows/sync-packages.yml
+++ b/.github/workflows/sync-packages.yml
@@ -29,12 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
 
       - name: Sync to public repos (creates release PRs)
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
-          GH_PAT: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_PAT: ${{ secrets.CI_GITHUB_TOKEN }}
           GIT_EMAIL: 'jbcom-bot@users.noreply.github.com'
           GIT_USERNAME: 'jbcom-bot'
           SKIP_PR: false  # Create PRs in public repos

--- a/packages/ECOSYSTEM.toml
+++ b/packages/ECOSYSTEM.toml
@@ -65,7 +65,7 @@ dependents = []
 trigger_on = ["push", "release", "workflow_dispatch"]
 creates_prs = true
 pr_prefix = "🚀 Release from control-center"
-uses_secret = "GITHUB_JBCOM_TOKEN"
+uses_secret = "CI_GITHUB_TOKEN"
 
 # Standards
 [standards]


### PR DESCRIPTION
Use existing secret that's already configured

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace GITHUB_JBCOM_TOKEN with JBCOM_DEPLOY_TOKEN in the sync workflow and ecosystem config.
> 
> - **CI / Workflows**:
>   - Update `.github/workflows/sync-packages.yml` to use `${{ secrets.JBCOM_DEPLOY_TOKEN }}` for `actions/checkout` `token` and `BetaHuhn/repo-file-sync-action` `GH_PAT`.
> - **Configuration**:
>   - Set `packages/ECOSYSTEM.toml` `[sync].uses_secret` to `JBCOM_DEPLOY_TOKEN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1515b5ae8c2a6e7851b70105e75e7e829877d3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->