### PR TITLE
Fix sync config

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -3,16 +3,16 @@
 
 jbcom/extended-data-types:
   - source: packages/extended-data-types/
-    dest: /
+    dest: .
 
 jbcom/lifecyclelogging:
   - source: packages/lifecyclelogging/
-    dest: /
+    dest: .
 
 jbcom/directed-inputs-class:
   - source: packages/directed-inputs-class/
-    dest: /
+    dest: .
 
 jbcom/vendor-connectors:
   - source: packages/vendor-connectors/
-    dest: /
+    dest: .

--- a/.github/workflows/sync-packages.yml
+++ b/.github/workflows/sync-packages.yml
@@ -37,10 +37,10 @@ jobs:
           GH_PAT: ${{ secrets.CI_GITHUB_TOKEN }}
           GIT_EMAIL: 'jbcom-bot@users.noreply.github.com'
           GIT_USERNAME: 'jbcom-bot'
-          SKIP_PR: false  # Create PRs in public repos
+          SKIP_PR: false
           CONFIG_PATH: .github/sync.yml
-          COMMIT_PREFIX: '🔄 Release'
-          PR_TITLE: '🚀 Release from control-center'
+          COMMIT_PREFIX: '🚀 Release from control-center:'
+          COMMIT_AS_PR_TITLE: true
           PR_BODY: |
             Automated release sync from jbcom-control-center.
             


### PR DESCRIPTION
- dest: . instead of /
- Use COMMIT_AS_PR_TITLE instead of invalid PR_TITLE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Point sync targets to repo root using `dest: .` and configure release PRs to use commit messages as titles with a new commit prefix.
> 
> - **CI / Sync Config**:
>   - Update `.github/sync.yml` to use `dest: .` for `jbcom/*` package sync targets.
> - **Workflow (`.github/workflows/sync-packages.yml`)**:
>   - Keep `SKIP_PR: false`; remove invalid `PR_TITLE` and enable `COMMIT_AS_PR_TITLE: true`.
>   - Change `COMMIT_PREFIX` to `"🚀 Release from control-center:"`.
>   - Preserve `PR_BODY`; no logic changes to triggers or steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf14d4cf3bd2043c1a5cf45722d3522e48bf8b47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->