### PR TITLE
docs: Monorepo architecture rules for all agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -881,247 +881,214 @@ When possible avoid:
 
 # Ecosystem Repositories
 
-This template manages and coordinates the jbcom Python library ecosystem.
-
-## Managed Repositories
-
-### 1. extended-data-types
-**Repository:** https://github.com/jbcom/extended-data-types
-**PyPI:** https://pypi.org/project/extended-data-types/
-**Latest Version:** 2025.11.164
-**Purpose:** Foundation library providing extended data type utilities
-
-**Key Features:**
-- `get_unique_signature()` - Generate unique signatures for objects
-- `make_raw_data_export_safe()` - Sanitize data for export/logging
-- `strtobool()` - Convert strings to booleans reliably
-- `strtopath()` - Convert strings to Path objects with validation
-- Data type conversions and utilities
-- Safe serialization helpers
-
-**Dependencies:** Minimal - this is a foundational library
-**Dependents:** lifecyclelogging, directed-inputs-class, vendor-connectors
-
-**Management Tasks:**
-- Keep dependencies minimal
-- Maintain backward compatibility
-- Comprehensive testing (100% coverage goal)
-- Performance optimization
-- Type hint completeness
-
-### 2. lifecyclelogging
-**Repository:** https://github.com/jbcom/lifecyclelogging  
-**PyPI:** https://pypi.org/project/lifecyclelogging/
-**Purpose:** Structured logging library with lifecycle management
-
-**Key Features:**
-- Lifecycle-aware logging (start, progress, completion, error states)
-- Automatic data sanitization using extended-data-types
-- Context managers for log lifecycle
-- Structured log output formats
-- Integration with Python logging module
-
-**Dependencies:**
-- extended-data-types (for sanitization)
-
-**Management Tasks:**
-- Ensure all logged data is sanitized
-- Maintain logging performance
-- Keep API simple and intuitive
-- Documentation with examples
-- Integration tests
-
-### 3. directed-inputs-class
-**Repository:** https://github.com/jbcom/directed-inputs-class
-**PyPI:** TBD (upcoming)
-**Purpose:** Input validation and processing with type safety
-
-**Key Features:**
-- Declarative input validation
-- Type coercion and conversion
-- Dependency-based field processing
-- Error aggregation and reporting
-- Integration with extended-data-types
-
-**Dependencies:**
-- extended-data-types (for type conversions)
-
-**Status:** In development - needs template migration
-
-**Management Tasks:**
-- Migrate to python-library-template structure
-- Add comprehensive tests
-- Complete type hints
-- Documentation and examples
-- Release initial version to PyPI
-
-### 4. vendor-connectors
-**Repository:** https://github.com/jbcom/vendor-connectors
-**PyPI:** TBD (upcoming)
-**Purpose:** Unified interface for third-party service integrations
-
-**Key Features:**
-- Abstract connector interface
-- Common authentication patterns
-- Rate limiting and retry logic
-- Error handling and logging
-- Vendor-specific implementations
-
-**Dependencies:**
-- extended-data-types (for data handling)
-- lifecyclelogging (for connection lifecycle)
-
-**Status:** Planning/early development
-
-**Management Tasks:**
-- Design unified connector interface
-- Implement core abstract classes
-- Add vendor-specific connectors
-- Comprehensive testing with mocks
-- Security audit for credential handling
-
-## Ecosystem Dependencies
-
-```
-extended-data-types (foundation)
-  ↓
-  ├── lifecyclelogging
-  ├── directed-inputs-class
-  └── vendor-connectors
-       ↑
-       └── uses lifecyclelogging
-```
-
-## Coordination Guidelines
-
-### Version Compatibility
-- All libraries use CalVer (YYYY.MM.BUILD)
-- Pin to minimum versions: `extended-data-types>=2025.11.0`
-- Test against latest versions in CI
-- Document breaking changes in CHANGELOG.md
-
-### Cross-Repository Changes
-
-When a change in one library affects others:
-
-1. **Plan the change:**
-   - Identify affected repositories
-   - Check if it's a breaking change
-   - Plan migration path if needed
-
-2. **Implementation order:**
-   - Update foundation libraries first (extended-data-types)
-   - Update dependent libraries in dependency order
-   - Test each library's CI passes
-
-3. **Release coordination:**
-   - Release foundation library first
-   - Wait for PyPI availability (~5 minutes)
-   - Update dependents to require new version
-   - Release dependent libraries
-
-4. **Communication:**
-   - Update CHANGELOG.md in each repo
-   - Document breaking changes
-   - Update this ecosystem doc
-
-### Adding New Ecosystem Libraries
-
-1. Create from python-library-template
-2. Follow the TEMPLATE_USAGE.md guide
-3. Add to this ecosystem document
-4. Configure PyPI trusted publishing
-5. First release via main branch push
-
-### Centralized Management Tasks
-
-From this repository, agents can:
-
-**Update dependencies across ecosystem:**
-```bash
-# Update security patches
-for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
-  cd ../$repo
-  # Update pyproject.toml dependencies
-  # Run tests
-  # Create PR if needed
-done
-```
-
-**Run ecosystem-wide checks:**
-```bash
-# Check all repos have consistent tooling
-# Verify all use same ruff/mypy/pytest configs
-# Ensure all CIs are up to date
-```
-
-**Coordinate releases:**
-```bash
-# When updating template CI
-# Push updates to all managed repos
-# Ensure compatibility
-```
-
-## Ecosystem Maintenance Schedule
-
-### Weekly
-- Check for dependency updates
-- Run security audits
-- Monitor PyPI download stats
-- Review open issues/PRs
-
-### Monthly  
-- Update Python version support
-- Refresh documentation
-- Performance benchmarks
-- Dependency cleanup
-
-### Quarterly
-- Major feature planning
-- Breaking change coordination
-- Ecosystem health review
-- Documentation overhaul
-
-## Agent Instructions for Ecosystem Work
-
-### When Working on extended-data-types
-
-This is the foundation - be extra careful:
-- All changes must maintain backward compatibility
-- 100% test coverage required
-- Performance regressions not acceptable
-- Breaking changes require ecosystem-wide coordination
-
-### When Working on dependent libraries
-
-- Always use extended-data-types utilities
-- Don't reimplement what extended-data-types provides
-- Keep dependencies minimal
-- Document any extended-data-types features you rely on
-
-### Cross-repo refactoring
-
-1. Start in this template repo
-2. Test changes in extended-data-types first
-3. Roll out to other libs in dependency order
-4. Create PRs, don't auto-merge
-5. Verify each library's CI independently
-
-### Emergency fixes
-
-For security issues or critical bugs:
-1. Fix in affected library immediately
-2. Create hotfix PR
-3. Fast-track review and merge
-4. Release immediately
-5. Update dependent libraries if needed
-6. Document in CHANGELOG.md
+This control center manages the jbcom Python library ecosystem via **MONOREPO ARCHITECTURE**.
 
 ---
 
-**Ecosystem Health:** All libraries production-ready and actively maintained
-**Coordination:** Centralized via this template repository
-**Next Library:** vendor-connectors (in planning)
+## 🏗️ ARCHITECTURE: All Code Lives Here
+
+**ALL Python ecosystem code is in `packages/` in this repository.**
+
+```
+jbcom-control-center/packages/
+├── extended-data-types/    → syncs to → jbcom/extended-data-types → PyPI
+├── lifecyclelogging/       → syncs to → jbcom/lifecyclelogging → PyPI
+├── directed-inputs-class/  → syncs to → jbcom/directed-inputs-class → PyPI
+└── vendor-connectors/      → syncs to → jbcom/vendor-connectors → PyPI
+```
+
+### Workflow
+1. **Edit** code in `packages/`
+2. **PR** to control-center main
+3. **Sync workflow** creates PRs in public repos
+4. **Merge** public PRs → CI → PyPI release
+
+### Why Monorepo
+- ✅ No cloning external repos
+- ✅ No GitHub API gymnastics
+- ✅ Single source of truth
+- ✅ Cross-package changes in ONE PR
+- ✅ Dependencies always aligned
+
+---
+
+## 📦 Package Details
+
+### 1. extended-data-types (FOUNDATION)
+**Location:** `packages/extended-data-types/`
+**PyPI:** `extended-data-types`
+**Public Repo:** `jbcom/extended-data-types`
+
+The foundation library - ALL other packages depend on this.
+
+**Provides:**
+- Re-exported libraries: `gitpython`, `inflection`, `lark`, `orjson`, `python-hcl2`, `ruamel.yaml`, `sortedcontainers`, `wrapt`
+- Utilities: `strtobool`, `strtopath`, `make_raw_data_export_safe`, `get_unique_signature`
+- Serialization: `decode_yaml`, `encode_yaml`, `decode_json`, `encode_json`
+- Collections: `flatten_map`, `filter_map`, and more
+
+**Rule:** Before adding ANY dependency to other packages, check if extended-data-types provides it.
+
+### 2. lifecyclelogging
+**Location:** `packages/lifecyclelogging/`
+**PyPI:** `lifecyclelogging`
+**Public Repo:** `jbcom/lifecyclelogging`
+
+Structured lifecycle logging with automatic sanitization.
+
+**Depends on:** extended-data-types
+
+### 3. directed-inputs-class
+**Location:** `packages/directed-inputs-class/`
+**PyPI:** `directed-inputs-class`
+**Public Repo:** `jbcom/directed-inputs-class`
+
+Declarative input validation and processing.
+
+**Depends on:** extended-data-types
+
+### 4. vendor-connectors
+**Location:** `packages/vendor-connectors/`
+**PyPI:** `cloud-connectors`
+**Public Repo:** `jbcom/vendor-connectors`
+
+Unified cloud provider connectors (AWS, GCP, GitHub, Slack, Vault, Zoom).
+
+**Depends on:** extended-data-types, lifecyclelogging
+
+---
+
+## 🔗 Dependency Chain
+
+```
+extended-data-types (FOUNDATION)
+├── lifecyclelogging
+├── directed-inputs-class
+└── vendor-connectors (depends on BOTH)
+```
+
+**Release Order:** Always release in this order:
+1. extended-data-types
+2. lifecyclelogging  
+3. directed-inputs-class
+4. vendor-connectors
+
+---
+
+## 🔧 Working With Packages
+
+### Edit Code
+```bash
+# Just edit files directly!
+vim packages/extended-data-types/src/extended_data_types/type_utils.py
+vim packages/vendor-connectors/pyproject.toml
+```
+
+### Run Tests
+```bash
+cd packages/extended-data-types && pip install -e ".[tests]" && pytest
+cd packages/lifecyclelogging && pip install -e ".[tests]" && pytest
+```
+
+### Align Dependencies
+```bash
+# Update version across all packages
+sed -i 's/extended-data-types>=.*/extended-data-types>=2025.11.200/' \
+  packages/*/pyproject.toml
+```
+
+### Create PR
+```bash
+git checkout -b fix/whatever
+git add -A && git commit -m "Fix: description"
+git push -u origin fix/whatever
+gh pr create --title "Fix: whatever"
+```
+
+---
+
+## 🔄 Sync Configuration
+
+### Files
+- `packages/ECOSYSTEM.toml` - Source of truth
+- `.github/sync.yml` - What syncs where
+- `.github/workflows/sync-packages.yml` - Sync workflow
+
+### Triggers
+- Push to main with `packages/**` changes
+- Manual workflow dispatch
+- Release published
+
+### Secret
+`CI_GITHUB_TOKEN` from Doppler - has write access to all jbcom repos
+
+---
+
+## ⚠️ Rules
+
+### DO
+- ✅ Edit code in `packages/` directly
+- ✅ Use regular git for this repo
+- ✅ Check `packages/ECOSYSTEM.toml` for relationships
+- ✅ Use extended-data-types utilities
+- ✅ Release in dependency order
+
+### DON'T
+- ❌ Clone external repos - code is HERE
+- ❌ Add duplicate utilities
+- ❌ Skip the sync workflow
+- ❌ Push directly to main (use PRs)
+
+---
+
+## 🎯 Eliminate Duplication
+
+### Check Before Adding Dependencies
+Always check `packages/extended-data-types/pyproject.toml` first.
+
+### Red Flags
+- `utils.py` > 100 lines → duplicating extended-data-types
+- Direct `import inflection` → should use extended-data-types
+- Custom JSON/YAML functions → use `encode_json`, `decode_yaml`
+
+### Correct Pattern
+```python
+# ✅ Use foundation library
+from extended_data_types import strtobool, make_raw_data_export_safe
+
+# ❌ Don't reimplement
+def my_str_to_bool(val):
+    return val.lower() in ("true", "yes", "1")
+```
+
+---
+
+## 📊 Health Checks
+
+### Check Public Repo CI
+```bash
+for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
+  gh run list --repo jbcom/$repo --limit 3
+done
+```
+
+### Check PyPI Versions
+```bash
+pip index versions extended-data-types
+pip index versions lifecyclelogging
+pip index versions cloud-connectors
+```
+
+### Trigger Manual Sync
+```bash
+gh workflow run "Sync Packages to Public Repos" --repo jbcom/jbcom-control-center
+```
+
+---
+
+**Source of Truth:** `packages/ECOSYSTEM.toml`
+**All code is in:** `packages/`
+**Sync handles:** Pushing to public repos and PyPI
 
 
 

--- a/.ruler/ecosystem.md
+++ b/.ruler/ecosystem.md
@@ -1,318 +1,210 @@
 # Ecosystem Repositories
 
-This template manages and coordinates the jbcom Python library ecosystem.
+This control center manages the jbcom Python library ecosystem via **MONOREPO ARCHITECTURE**.
 
-## Managed Repositories
+---
 
-### 1. extended-data-types
-**Repository:** https://github.com/jbcom/extended-data-types
-**PyPI:** https://pypi.org/project/extended-data-types/
-**Latest Version:** 2025.11.164
-**Purpose:** Foundation library providing extended data type utilities
+## 🏗️ ARCHITECTURE: All Code Lives Here
 
-**Key Features:**
-- `get_unique_signature()` - Generate unique signatures for objects
-- `make_raw_data_export_safe()` - Sanitize data for export/logging
-- `strtobool()` - Convert strings to booleans reliably
-- `strtopath()` - Convert strings to Path objects with validation
-- Data type conversions and utilities
-- Safe serialization helpers
+**ALL Python ecosystem code is in `packages/` in this repository.**
 
-**Dependencies:** Minimal - this is a foundational library
-**Dependents:** lifecyclelogging, directed-inputs-class, vendor-connectors
+```
+jbcom-control-center/packages/
+├── extended-data-types/    → syncs to → jbcom/extended-data-types → PyPI
+├── lifecyclelogging/       → syncs to → jbcom/lifecyclelogging → PyPI
+├── directed-inputs-class/  → syncs to → jbcom/directed-inputs-class → PyPI
+└── vendor-connectors/      → syncs to → jbcom/vendor-connectors → PyPI
+```
 
-**Management Tasks:**
-- Keep dependencies minimal
-- Maintain backward compatibility
-- Comprehensive testing (100% coverage goal)
-- Performance optimization
-- Type hint completeness
+### Workflow
+1. **Edit** code in `packages/`
+2. **PR** to control-center main
+3. **Sync workflow** creates PRs in public repos
+4. **Merge** public PRs → CI → PyPI release
+
+### Why Monorepo
+- ✅ No cloning external repos
+- ✅ No GitHub API gymnastics
+- ✅ Single source of truth
+- ✅ Cross-package changes in ONE PR
+- ✅ Dependencies always aligned
+
+---
+
+## 📦 Package Details
+
+### 1. extended-data-types (FOUNDATION)
+**Location:** `packages/extended-data-types/`
+**PyPI:** `extended-data-types`
+**Public Repo:** `jbcom/extended-data-types`
+
+The foundation library - ALL other packages depend on this.
+
+**Provides:**
+- Re-exported libraries: `gitpython`, `inflection`, `lark`, `orjson`, `python-hcl2`, `ruamel.yaml`, `sortedcontainers`, `wrapt`
+- Utilities: `strtobool`, `strtopath`, `make_raw_data_export_safe`, `get_unique_signature`
+- Serialization: `decode_yaml`, `encode_yaml`, `decode_json`, `encode_json`
+- Collections: `flatten_map`, `filter_map`, and more
+
+**Rule:** Before adding ANY dependency to other packages, check if extended-data-types provides it.
 
 ### 2. lifecyclelogging
-**Repository:** https://github.com/jbcom/lifecyclelogging  
-**PyPI:** https://pypi.org/project/lifecyclelogging/
-**Purpose:** Structured logging library with lifecycle management
+**Location:** `packages/lifecyclelogging/`
+**PyPI:** `lifecyclelogging`
+**Public Repo:** `jbcom/lifecyclelogging`
 
-**Key Features:**
-- Lifecycle-aware logging (start, progress, completion, error states)
-- Automatic data sanitization using extended-data-types
-- Context managers for log lifecycle
-- Structured log output formats
-- Integration with Python logging module
+Structured lifecycle logging with automatic sanitization.
 
-**Dependencies:**
-- extended-data-types (for sanitization)
-
-**Management Tasks:**
-- Ensure all logged data is sanitized
-- Maintain logging performance
-- Keep API simple and intuitive
-- Documentation with examples
-- Integration tests
+**Depends on:** extended-data-types
 
 ### 3. directed-inputs-class
-**Repository:** https://github.com/jbcom/directed-inputs-class
-**PyPI:** TBD (upcoming)
-**Purpose:** Input validation and processing with type safety
+**Location:** `packages/directed-inputs-class/`
+**PyPI:** `directed-inputs-class`
+**Public Repo:** `jbcom/directed-inputs-class`
 
-**Key Features:**
-- Declarative input validation
-- Type coercion and conversion
-- Dependency-based field processing
-- Error aggregation and reporting
-- Integration with extended-data-types
+Declarative input validation and processing.
 
-**Dependencies:**
-- extended-data-types (for type conversions)
-
-**Status:** In development - needs template migration
-
-**Management Tasks:**
-- Migrate to python-library-template structure
-- Add comprehensive tests
-- Complete type hints
-- Documentation and examples
-- Release initial version to PyPI
+**Depends on:** extended-data-types
 
 ### 4. vendor-connectors
-**Repository:** https://github.com/jbcom/vendor-connectors
-**PyPI:** TBD (upcoming)
-**Purpose:** Unified interface for third-party service integrations
+**Location:** `packages/vendor-connectors/`
+**PyPI:** `cloud-connectors`
+**Public Repo:** `jbcom/vendor-connectors`
 
-**Key Features:**
-- Abstract connector interface
-- Common authentication patterns
-- Rate limiting and retry logic
-- Error handling and logging
-- Vendor-specific implementations
+Unified cloud provider connectors (AWS, GCP, GitHub, Slack, Vault, Zoom).
 
-**Dependencies:**
-- extended-data-types (for data handling)
-- lifecyclelogging (for connection lifecycle)
+**Depends on:** extended-data-types, lifecyclelogging
 
-**Status:** Planning/early development
+---
 
-**Management Tasks:**
-- Design unified connector interface
-- Implement core abstract classes
-- Add vendor-specific connectors
-- Comprehensive testing with mocks
-- Security audit for credential handling
-
-## Ecosystem Dependencies
+## 🔗 Dependency Chain
 
 ```
-extended-data-types (foundation)
-  ↓
-  ├── lifecyclelogging
-  ├── directed-inputs-class
-  └── vendor-connectors
-       ↑
-       └── uses lifecyclelogging
+extended-data-types (FOUNDATION)
+├── lifecyclelogging
+├── directed-inputs-class
+└── vendor-connectors (depends on BOTH)
 ```
 
-## Coordination Guidelines
+**Release Order:** Always release in this order:
+1. extended-data-types
+2. lifecyclelogging  
+3. directed-inputs-class
+4. vendor-connectors
 
-### Version Compatibility
-- All libraries use CalVer (YYYY.MM.BUILD)
-- Pin to minimum versions: `extended-data-types>=2025.11.0`
-- Test against latest versions in CI
-- Document breaking changes in CHANGELOG.md
+---
 
-### Cross-Repository Changes
+## 🔧 Working With Packages
 
-When a change in one library affects others:
-
-1. **Plan the change:**
-   - Identify affected repositories
-   - Check if it's a breaking change
-   - Plan migration path if needed
-
-2. **Implementation order:**
-   - Update foundation libraries first (extended-data-types)
-   - Update dependent libraries in dependency order
-   - Test each library's CI passes
-
-3. **Release coordination:**
-   - Release foundation library first
-   - Wait for PyPI availability (~5 minutes)
-   - Update dependents to require new version
-   - Release dependent libraries
-
-4. **Communication:**
-   - Update CHANGELOG.md in each repo
-   - Document breaking changes
-   - Update this ecosystem doc
-
-### Adding New Ecosystem Libraries
-
-1. Create from python-library-template
-2. Follow the TEMPLATE_USAGE.md guide
-3. Add to this ecosystem document
-4. Configure PyPI trusted publishing
-5. First release via main branch push
-
-### Centralized Management Tasks
-
-From this repository, agents can:
-
-**Update dependencies across ecosystem:**
+### Edit Code
 ```bash
-# Update security patches
+# Just edit files directly!
+vim packages/extended-data-types/src/extended_data_types/type_utils.py
+vim packages/vendor-connectors/pyproject.toml
+```
+
+### Run Tests
+```bash
+cd packages/extended-data-types && pip install -e ".[tests]" && pytest
+cd packages/lifecyclelogging && pip install -e ".[tests]" && pytest
+```
+
+### Align Dependencies
+```bash
+# Update version across all packages
+sed -i 's/extended-data-types>=.*/extended-data-types>=2025.11.200/' \
+  packages/*/pyproject.toml
+```
+
+### Create PR
+```bash
+git checkout -b fix/whatever
+git add -A && git commit -m "Fix: description"
+git push -u origin fix/whatever
+gh pr create --title "Fix: whatever"
+```
+
+---
+
+## 🔄 Sync Configuration
+
+### Files
+- `packages/ECOSYSTEM.toml` - Source of truth
+- `.github/sync.yml` - What syncs where
+- `.github/workflows/sync-packages.yml` - Sync workflow
+
+### Triggers
+- Push to main with `packages/**` changes
+- Manual workflow dispatch
+- Release published
+
+### Secret
+`CI_GITHUB_TOKEN` from Doppler - has write access to all jbcom repos
+
+---
+
+## ⚠️ Rules
+
+### DO
+- ✅ Edit code in `packages/` directly
+- ✅ Use regular git for this repo
+- ✅ Check `packages/ECOSYSTEM.toml` for relationships
+- ✅ Use extended-data-types utilities
+- ✅ Release in dependency order
+
+### DON'T
+- ❌ Clone external repos - code is HERE
+- ❌ Add duplicate utilities
+- ❌ Skip the sync workflow
+- ❌ Push directly to main (use PRs)
+
+---
+
+## 🎯 Eliminate Duplication
+
+### Check Before Adding Dependencies
+Always check `packages/extended-data-types/pyproject.toml` first.
+
+### Red Flags
+- `utils.py` > 100 lines → duplicating extended-data-types
+- Direct `import inflection` → should use extended-data-types
+- Custom JSON/YAML functions → use `encode_json`, `decode_yaml`
+
+### Correct Pattern
+```python
+# ✅ Use foundation library
+from extended_data_types import strtobool, make_raw_data_export_safe
+
+# ❌ Don't reimplement
+def my_str_to_bool(val):
+    return val.lower() in ("true", "yes", "1")
+```
+
+---
+
+## 📊 Health Checks
+
+### Check Public Repo CI
+```bash
 for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
-  cd ../$repo
-  # Update pyproject.toml dependencies
-  # Run tests
-  # Create PR if needed
+  gh run list --repo jbcom/$repo --limit 3
 done
 ```
 
-**Run ecosystem-wide checks:**
+### Check PyPI Versions
 ```bash
-# Check all repos have consistent tooling
-# Verify all use same ruff/mypy/pytest configs
-# Ensure all CIs are up to date
+pip index versions extended-data-types
+pip index versions lifecyclelogging
+pip index versions cloud-connectors
 ```
 
-**Coordinate releases:**
+### Trigger Manual Sync
 ```bash
-# When updating template CI
-# Push updates to all managed repos
-# Ensure compatibility
-```
-
-## Ecosystem Maintenance Schedule
-
-### Weekly
-- Check for dependency updates
-- Run security audits
-- Monitor PyPI download stats
-- Review open issues/PRs
-
-### Monthly  
-- Update Python version support
-- Refresh documentation
-- Performance benchmarks
-- Dependency cleanup
-
-### Quarterly
-- Major feature planning
-- Breaking change coordination
-- Ecosystem health review
-- Documentation overhaul
-
-## 🚨 CRITICAL: How to Push to Remote Repositories
-
-**NEVER use `git push` directly** - it will fail with permission errors.
-
-**ALWAYS use GitHub API:**
-```bash
-# Create branch
-MAIN_SHA=$(gh api repos/jbcom/REPO/git/refs/heads/main --jq '.object.sha')
-gh api repos/jbcom/REPO/git/refs -X POST -f ref="refs/heads/BRANCH" -f sha="$MAIN_SHA"
-
-# Update file (base64 encoded)
-FILE_SHA=$(gh api repos/jbcom/REPO/contents/PATH --jq '.sha')
-gh api repos/jbcom/REPO/contents/PATH -X PUT \
-  -f message="msg" -f content="$(base64 -w 0 FILE)" -f sha="$FILE_SHA" -f branch="BRANCH"
-
-# Create PR and merge
-gh pr create --repo jbcom/REPO --base main --head BRANCH --title "..." --body "..."
-gh pr merge NUM --repo jbcom/REPO --squash --delete-branch --admin
+gh workflow run "Sync Packages to Public Repos" --repo jbcom/jbcom-control-center
 ```
 
 ---
 
-## 🔄 SYNCHRONIZE: Dependency Alignment
-
-**All repos MUST use CalVer versions:**
-```toml
-# ✅ CORRECT
-"extended-data-types>=2025.11.0"
-"lifecyclelogging>=2025.11.0"
-
-# ❌ WRONG
-"extended-data-types>=5.0.0"
-```
-
-**Check alignment:**
-```bash
-pip index versions extended-data-types  # Latest on PyPI
-gh api repos/jbcom/REPO/contents/pyproject.toml  # What repo uses
-```
-
----
-
-## ⬆️ UPGRADE: Propagation Order
-
-When foundation updates, propagate in this order:
-1. `extended-data-types` (foundation)
-2. `lifecyclelogging` (depends on #1)
-3. `directed-inputs-class` (depends on #1)
-4. `vendor-connectors` (depends on #1 and #2)
-
----
-
-## 🎯 ALIGN: No Duplication
-
-**extended-data-types provides these - DO NOT add separately:**
-- gitpython, inflection, lark, orjson, python-hcl2, ruamel.yaml, sortedcontainers, wrapt
-
-**Use utilities from extended-data-types:**
-```python
-from extended_data_types import strtobool, make_raw_data_export_safe, decode_yaml
-```
-
-**Red flags:**
-- `utils.py` > 100 lines = probably duplicating
-- Direct `import inflection` = should come via extended-data-types
-- Custom YAML/JSON functions = use extended-data-types
-
----
-
-## Agent Instructions for Ecosystem Work
-
-### When Working on extended-data-types
-
-This is the foundation - be extra careful:
-- All changes must maintain backward compatibility
-- 100% test coverage required
-- Performance regressions not acceptable
-- Breaking changes require ecosystem-wide coordination
-
-### When Working on dependent libraries
-
-- Always use extended-data-types utilities
-- Don't reimplement what extended-data-types provides
-- Keep dependencies minimal
-- Document any extended-data-types features you rely on
-
-### Cross-repo refactoring
-
-1. Start in this template repo
-2. Test changes in extended-data-types first
-3. Roll out to other libs in dependency order
-4. Create PRs via GitHub API (not git push!)
-5. Verify each library's CI independently
-
-### Emergency fixes
-
-For security issues or critical bugs:
-1. Fix in affected library immediately
-2. Create hotfix PR via GitHub API
-3. Fast-track review and merge
-4. Release immediately
-5. Update dependent libraries if needed
-6. Document in CHANGELOG.md
-
----
-
-**Ecosystem Health:** All libraries production-ready and actively maintained
-**Coordination:** Centralized via this template repository
-**Next Library:** vendor-connectors (in planning)
-
-**NEVER FORGET:**
-- GitHub API for pushing (not git push)
-- CalVer versions only (2025.MM.BUILD)
-- Upgrade in dependency order
-- Use extended-data-types, don't duplicate
+**Source of Truth:** `packages/ECOSYSTEM.toml`
+**All code is in:** `packages/`
+**Sync handles:** Pushing to public repos and PyPI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -881,247 +881,214 @@ When possible avoid:
 
 # Ecosystem Repositories
 
-This template manages and coordinates the jbcom Python library ecosystem.
-
-## Managed Repositories
-
-### 1. extended-data-types
-**Repository:** https://github.com/jbcom/extended-data-types
-**PyPI:** https://pypi.org/project/extended-data-types/
-**Latest Version:** 2025.11.164
-**Purpose:** Foundation library providing extended data type utilities
-
-**Key Features:**
-- `get_unique_signature()` - Generate unique signatures for objects
-- `make_raw_data_export_safe()` - Sanitize data for export/logging
-- `strtobool()` - Convert strings to booleans reliably
-- `strtopath()` - Convert strings to Path objects with validation
-- Data type conversions and utilities
-- Safe serialization helpers
-
-**Dependencies:** Minimal - this is a foundational library
-**Dependents:** lifecyclelogging, directed-inputs-class, vendor-connectors
-
-**Management Tasks:**
-- Keep dependencies minimal
-- Maintain backward compatibility
-- Comprehensive testing (100% coverage goal)
-- Performance optimization
-- Type hint completeness
-
-### 2. lifecyclelogging
-**Repository:** https://github.com/jbcom/lifecyclelogging  
-**PyPI:** https://pypi.org/project/lifecyclelogging/
-**Purpose:** Structured logging library with lifecycle management
-
-**Key Features:**
-- Lifecycle-aware logging (start, progress, completion, error states)
-- Automatic data sanitization using extended-data-types
-- Context managers for log lifecycle
-- Structured log output formats
-- Integration with Python logging module
-
-**Dependencies:**
-- extended-data-types (for sanitization)
-
-**Management Tasks:**
-- Ensure all logged data is sanitized
-- Maintain logging performance
-- Keep API simple and intuitive
-- Documentation with examples
-- Integration tests
-
-### 3. directed-inputs-class
-**Repository:** https://github.com/jbcom/directed-inputs-class
-**PyPI:** TBD (upcoming)
-**Purpose:** Input validation and processing with type safety
-
-**Key Features:**
-- Declarative input validation
-- Type coercion and conversion
-- Dependency-based field processing
-- Error aggregation and reporting
-- Integration with extended-data-types
-
-**Dependencies:**
-- extended-data-types (for type conversions)
-
-**Status:** In development - needs template migration
-
-**Management Tasks:**
-- Migrate to python-library-template structure
-- Add comprehensive tests
-- Complete type hints
-- Documentation and examples
-- Release initial version to PyPI
-
-### 4. vendor-connectors
-**Repository:** https://github.com/jbcom/vendor-connectors
-**PyPI:** TBD (upcoming)
-**Purpose:** Unified interface for third-party service integrations
-
-**Key Features:**
-- Abstract connector interface
-- Common authentication patterns
-- Rate limiting and retry logic
-- Error handling and logging
-- Vendor-specific implementations
-
-**Dependencies:**
-- extended-data-types (for data handling)
-- lifecyclelogging (for connection lifecycle)
-
-**Status:** Planning/early development
-
-**Management Tasks:**
-- Design unified connector interface
-- Implement core abstract classes
-- Add vendor-specific connectors
-- Comprehensive testing with mocks
-- Security audit for credential handling
-
-## Ecosystem Dependencies
-
-```
-extended-data-types (foundation)
-  ↓
-  ├── lifecyclelogging
-  ├── directed-inputs-class
-  └── vendor-connectors
-       ↑
-       └── uses lifecyclelogging
-```
-
-## Coordination Guidelines
-
-### Version Compatibility
-- All libraries use CalVer (YYYY.MM.BUILD)
-- Pin to minimum versions: `extended-data-types>=2025.11.0`
-- Test against latest versions in CI
-- Document breaking changes in CHANGELOG.md
-
-### Cross-Repository Changes
-
-When a change in one library affects others:
-
-1. **Plan the change:**
-   - Identify affected repositories
-   - Check if it's a breaking change
-   - Plan migration path if needed
-
-2. **Implementation order:**
-   - Update foundation libraries first (extended-data-types)
-   - Update dependent libraries in dependency order
-   - Test each library's CI passes
-
-3. **Release coordination:**
-   - Release foundation library first
-   - Wait for PyPI availability (~5 minutes)
-   - Update dependents to require new version
-   - Release dependent libraries
-
-4. **Communication:**
-   - Update CHANGELOG.md in each repo
-   - Document breaking changes
-   - Update this ecosystem doc
-
-### Adding New Ecosystem Libraries
-
-1. Create from python-library-template
-2. Follow the TEMPLATE_USAGE.md guide
-3. Add to this ecosystem document
-4. Configure PyPI trusted publishing
-5. First release via main branch push
-
-### Centralized Management Tasks
-
-From this repository, agents can:
-
-**Update dependencies across ecosystem:**
-```bash
-# Update security patches
-for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
-  cd ../$repo
-  # Update pyproject.toml dependencies
-  # Run tests
-  # Create PR if needed
-done
-```
-
-**Run ecosystem-wide checks:**
-```bash
-# Check all repos have consistent tooling
-# Verify all use same ruff/mypy/pytest configs
-# Ensure all CIs are up to date
-```
-
-**Coordinate releases:**
-```bash
-# When updating template CI
-# Push updates to all managed repos
-# Ensure compatibility
-```
-
-## Ecosystem Maintenance Schedule
-
-### Weekly
-- Check for dependency updates
-- Run security audits
-- Monitor PyPI download stats
-- Review open issues/PRs
-
-### Monthly  
-- Update Python version support
-- Refresh documentation
-- Performance benchmarks
-- Dependency cleanup
-
-### Quarterly
-- Major feature planning
-- Breaking change coordination
-- Ecosystem health review
-- Documentation overhaul
-
-## Agent Instructions for Ecosystem Work
-
-### When Working on extended-data-types
-
-This is the foundation - be extra careful:
-- All changes must maintain backward compatibility
-- 100% test coverage required
-- Performance regressions not acceptable
-- Breaking changes require ecosystem-wide coordination
-
-### When Working on dependent libraries
-
-- Always use extended-data-types utilities
-- Don't reimplement what extended-data-types provides
-- Keep dependencies minimal
-- Document any extended-data-types features you rely on
-
-### Cross-repo refactoring
-
-1. Start in this template repo
-2. Test changes in extended-data-types first
-3. Roll out to other libs in dependency order
-4. Create PRs, don't auto-merge
-5. Verify each library's CI independently
-
-### Emergency fixes
-
-For security issues or critical bugs:
-1. Fix in affected library immediately
-2. Create hotfix PR
-3. Fast-track review and merge
-4. Release immediately
-5. Update dependent libraries if needed
-6. Document in CHANGELOG.md
+This control center manages the jbcom Python library ecosystem via **MONOREPO ARCHITECTURE**.
 
 ---
 
-**Ecosystem Health:** All libraries production-ready and actively maintained
-**Coordination:** Centralized via this template repository
-**Next Library:** vendor-connectors (in planning)
+## 🏗️ ARCHITECTURE: All Code Lives Here
+
+**ALL Python ecosystem code is in `packages/` in this repository.**
+
+```
+jbcom-control-center/packages/
+├── extended-data-types/    → syncs to → jbcom/extended-data-types → PyPI
+├── lifecyclelogging/       → syncs to → jbcom/lifecyclelogging → PyPI
+├── directed-inputs-class/  → syncs to → jbcom/directed-inputs-class → PyPI
+└── vendor-connectors/      → syncs to → jbcom/vendor-connectors → PyPI
+```
+
+### Workflow
+1. **Edit** code in `packages/`
+2. **PR** to control-center main
+3. **Sync workflow** creates PRs in public repos
+4. **Merge** public PRs → CI → PyPI release
+
+### Why Monorepo
+- ✅ No cloning external repos
+- ✅ No GitHub API gymnastics
+- ✅ Single source of truth
+- ✅ Cross-package changes in ONE PR
+- ✅ Dependencies always aligned
+
+---
+
+## 📦 Package Details
+
+### 1. extended-data-types (FOUNDATION)
+**Location:** `packages/extended-data-types/`
+**PyPI:** `extended-data-types`
+**Public Repo:** `jbcom/extended-data-types`
+
+The foundation library - ALL other packages depend on this.
+
+**Provides:**
+- Re-exported libraries: `gitpython`, `inflection`, `lark`, `orjson`, `python-hcl2`, `ruamel.yaml`, `sortedcontainers`, `wrapt`
+- Utilities: `strtobool`, `strtopath`, `make_raw_data_export_safe`, `get_unique_signature`
+- Serialization: `decode_yaml`, `encode_yaml`, `decode_json`, `encode_json`
+- Collections: `flatten_map`, `filter_map`, and more
+
+**Rule:** Before adding ANY dependency to other packages, check if extended-data-types provides it.
+
+### 2. lifecyclelogging
+**Location:** `packages/lifecyclelogging/`
+**PyPI:** `lifecyclelogging`
+**Public Repo:** `jbcom/lifecyclelogging`
+
+Structured lifecycle logging with automatic sanitization.
+
+**Depends on:** extended-data-types
+
+### 3. directed-inputs-class
+**Location:** `packages/directed-inputs-class/`
+**PyPI:** `directed-inputs-class`
+**Public Repo:** `jbcom/directed-inputs-class`
+
+Declarative input validation and processing.
+
+**Depends on:** extended-data-types
+
+### 4. vendor-connectors
+**Location:** `packages/vendor-connectors/`
+**PyPI:** `cloud-connectors`
+**Public Repo:** `jbcom/vendor-connectors`
+
+Unified cloud provider connectors (AWS, GCP, GitHub, Slack, Vault, Zoom).
+
+**Depends on:** extended-data-types, lifecyclelogging
+
+---
+
+## 🔗 Dependency Chain
+
+```
+extended-data-types (FOUNDATION)
+├── lifecyclelogging
+├── directed-inputs-class
+└── vendor-connectors (depends on BOTH)
+```
+
+**Release Order:** Always release in this order:
+1. extended-data-types
+2. lifecyclelogging  
+3. directed-inputs-class
+4. vendor-connectors
+
+---
+
+## 🔧 Working With Packages
+
+### Edit Code
+```bash
+# Just edit files directly!
+vim packages/extended-data-types/src/extended_data_types/type_utils.py
+vim packages/vendor-connectors/pyproject.toml
+```
+
+### Run Tests
+```bash
+cd packages/extended-data-types && pip install -e ".[tests]" && pytest
+cd packages/lifecyclelogging && pip install -e ".[tests]" && pytest
+```
+
+### Align Dependencies
+```bash
+# Update version across all packages
+sed -i 's/extended-data-types>=.*/extended-data-types>=2025.11.200/' \
+  packages/*/pyproject.toml
+```
+
+### Create PR
+```bash
+git checkout -b fix/whatever
+git add -A && git commit -m "Fix: description"
+git push -u origin fix/whatever
+gh pr create --title "Fix: whatever"
+```
+
+---
+
+## 🔄 Sync Configuration
+
+### Files
+- `packages/ECOSYSTEM.toml` - Source of truth
+- `.github/sync.yml` - What syncs where
+- `.github/workflows/sync-packages.yml` - Sync workflow
+
+### Triggers
+- Push to main with `packages/**` changes
+- Manual workflow dispatch
+- Release published
+
+### Secret
+`CI_GITHUB_TOKEN` from Doppler - has write access to all jbcom repos
+
+---
+
+## ⚠️ Rules
+
+### DO
+- ✅ Edit code in `packages/` directly
+- ✅ Use regular git for this repo
+- ✅ Check `packages/ECOSYSTEM.toml` for relationships
+- ✅ Use extended-data-types utilities
+- ✅ Release in dependency order
+
+### DON'T
+- ❌ Clone external repos - code is HERE
+- ❌ Add duplicate utilities
+- ❌ Skip the sync workflow
+- ❌ Push directly to main (use PRs)
+
+---
+
+## 🎯 Eliminate Duplication
+
+### Check Before Adding Dependencies
+Always check `packages/extended-data-types/pyproject.toml` first.
+
+### Red Flags
+- `utils.py` > 100 lines → duplicating extended-data-types
+- Direct `import inflection` → should use extended-data-types
+- Custom JSON/YAML functions → use `encode_json`, `decode_yaml`
+
+### Correct Pattern
+```python
+# ✅ Use foundation library
+from extended_data_types import strtobool, make_raw_data_export_safe
+
+# ❌ Don't reimplement
+def my_str_to_bool(val):
+    return val.lower() in ("true", "yes", "1")
+```
+
+---
+
+## 📊 Health Checks
+
+### Check Public Repo CI
+```bash
+for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
+  gh run list --repo jbcom/$repo --limit 3
+done
+```
+
+### Check PyPI Versions
+```bash
+pip index versions extended-data-types
+pip index versions lifecyclelogging
+pip index versions cloud-connectors
+```
+
+### Trigger Manual Sync
+```bash
+gh workflow run "Sync Packages to Public Repos" --repo jbcom/jbcom-control-center
+```
+
+---
+
+**Source of Truth:** `packages/ECOSYSTEM.toml`
+**All code is in:** `packages/`
+**Sync handles:** Pushing to public repos and PyPI
 
 
 


### PR DESCRIPTION
## Summary
- Rewrote all agent documentation for the monorepo workflow
- All code lives in `packages/`, sync handles pushing to public repos
- Removed obsolete GitHub API push instructions
- Added sync workflow documentation

## Files Updated
- `.cursor/agents/jbcom-ecosystem-manager.md`
- `.ruler/ecosystem.md`
- `AGENTS.md` (via ruler apply)
- `.github/copilot-instructions.md` (via ruler apply)

## Key Points
- Edit code in `packages/` directly
- Use regular git for this repo
- Sync creates PRs in public repos
- No more cloning or API gymnastics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites ecosystem agent docs to make `packages/` the source of truth and document the automated sync-to-public-repos workflow, adding dependency/order rules and health checks while dropping GitHub API push instructions.
> 
> - **Docs overhaul (monorepo-first)**
>   - Centralize all Python code under `packages/` with `packages/ECOSYSTEM.toml` as the source of truth.
>   - Define dependency chain and enforced release order (`extended-data-types` → dependents).
>   - Document sync workflow (`.github/sync.yml`, `sync-packages.yml`): main push/dispatch triggers PRs to public repos → CI → PyPI.
>   - Add working guidelines: edit-in-place, PR flow, local testing, dependency alignment, manual sync trigger.
>   - Establish rules: no cloning/API gymnastics, no duplicate utilities (use `extended-data-types`).
>   - Add health checks: CI status, open PRs, PyPI version checks.
> - **Files updated**
>   - Rewrite `.cursor/agents/jbcom-ecosystem-manager.md` and `.ruler/ecosystem.md` with monorepo + sync guidance.
>   - Regenerate `AGENTS.md` and `.github/copilot-instructions.md` from ruler to reflect new ecosystem docs.
> - **Removed**
>   - Obsolete GitHub API-based push instructions in favor of sync workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f9074c66fb8c81c4173821d717350728475f237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->