### PR TITLE
fix(vendor-connectors): Fix CaseInsensitiveDict import

### DIFF
--- a/packages/vendor-connectors/pyproject.toml
+++ b/packages/vendor-connectors/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     # Additional utils not in extended-data-types
     "numpy>=1.26.0",
     "validators>=0.22.0",
-    "case-insensitive-dict>=0.1.0",
+    # CaseInsensitiveDict comes from requests (already a dependency)
     "deepmerge>=1.1.0",
     "filelock>=3.13.0",
     "more-itertools>=10.0.0",

--- a/packages/vendor-connectors/src/cloud_connectors/base/utils.py
+++ b/packages/vendor-connectors/src/cloud_connectors/base/utils.py
@@ -27,7 +27,7 @@ import numpy as np
 import orjson
 import requests
 import validators
-from case_insensitive_dict import CaseInsensitiveDict
+from requests.structures import CaseInsensitiveDict
 from deepmerge import Merger
 from filelock import FileLock, Timeout
 from git import Repo, InvalidGitRepositoryError, NoSuchPathError, GitCommandError


### PR DESCRIPTION
Replace broken case-insensitive-dict package with requests.structures.CaseInsensitiveDict

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to `requests.structures.CaseInsensitiveDict` and removes the redundant `case-insensitive-dict` dependency.
> 
> - **Core change**:
>   - Use `requests.structures.CaseInsensitiveDict` in `packages/vendor-connectors/src/cloud_connectors/base/utils.py`.
> - **Dependencies**:
>   - Remove `case-insensitive-dict` from `packages/vendor-connectors/pyproject.toml` (already provided by `requests`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cca8343b71111aed1956e7659ba5149fe1ee497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->