### PR TITLE
fix(vendor-connectors): Python 3.9 compatibility

### DIFF
--- a/packages/vendor-connectors/src/cloud_connectors/base/errors.py
+++ b/packages/vendor-connectors/src/cloud_connectors/base/errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from http import HTTPStatus
 from typing import Optional

--- a/packages/vendor-connectors/src/cloud_connectors/base/logging.py
+++ b/packages/vendor-connectors/src/cloud_connectors/base/logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import re

--- a/packages/vendor-connectors/src/cloud_connectors/base/utils.py
+++ b/packages/vendor-connectors/src/cloud_connectors/base/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import binascii
 import datetime


### PR DESCRIPTION
Add from __future__ import annotations for X|Y union syntax

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `from __future__ import annotations` to `base/errors.py`, `base/logging.py`, and `base/utils.py` to enable `X | Y` typing on Python 3.9.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c2f43546a57c93f32ddb973f6233a43adba1a40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->