### PR TITLE
fix(vendor-connectors): Ignore UP045 style rule

### DIFF
--- a/packages/vendor-connectors/pyproject.toml
+++ b/packages/vendor-connectors/pyproject.toml
@@ -117,6 +117,7 @@ ignore = [
     "B904",  # raise from err (too many changes needed)
     "C901",  # too complex
     "UP035", # deprecated typing imports (Python 3.9 compat)
+    "UP045", # Optional[X] vs X | None (keep Optional for clarity)
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Keep Optional[X] for clarity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `UP045` to `ruff` ignore list to allow `Optional[X]` usage without warnings.
> 
> - **Linting (ruff)**:
>   - Update `packages/vendor-connectors/pyproject.toml` to ignore `UP045` (allows `Optional[X]` vs `X | None`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90db78a94a9481f117e5cdd8e0fbb763335afb88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->