### PR TITLE
fix: CalVer YYYY.MMDD.BUILD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,8 @@ jobs:
         run: |
           pip install build twine
           
-          # Set CalVer version
-          VERSION="$(date +%Y).$(date +%-m).${{ github.run_number }}"
+          # Set CalVer version: YYYY.MMDD.BUILD
+          VERSION="$(date +%Y).$(date +%-m%d).${{ github.run_number }}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           
           # Update version in __init__.py


### PR DESCRIPTION
2025.1126.1 instead of 2025.11.166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release workflow to use CalVer YYYY.MMDD.BUILD (e.g., 2025.1126.1) instead of YYYY.M.BUILD.
> 
> - **CI/Release (`.github/workflows/release.yml`)**:
>   - Change CalVer computation to `YYYY.MMDD.BUILD` (`VERSION="$(date +%Y).$(date +%-m%d).${{ github.run_number }}"`).
>   - Update inline comment to reflect new format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 489198ea35e65ec45fa336e4d9a16dd711c92200. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->