### PR TITLE
fix: PyCalVer format YYYYMM.NNNN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,8 @@ jobs:
         run: |
           pip install build twine
           
-          # Set CalVer version: YYYY.MMDD.BUILD
-          VERSION="$(date +%Y).$(date +%-m%d).${{ github.run_number }}"
+          # PyCalVer format: YYYYMM.NNNN (e.g., 202511.0001)
+          VERSION="$(date +%Y%m).$(printf '%04d' ${{ github.run_number }})"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           
           # Update version in __init__.py


### PR DESCRIPTION
Standard format: 202511.0001

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches release workflow to PyCalVer (YYYYMM.NNNN) and adjusts VERSION computation accordingly.
> 
> - **CI/Release**:
>   - Switch versioning to PyCalVer `YYYYMM.NNNN` and compute `VERSION` via `date +%Y%m` and zero-padded `github.run_number`.
>   - Propagate new `VERSION` to `__init__.py` before build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1520ec3e4106041639dd3192770325f88f625d6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->