### PR TITLE
docs: GITHUB_JBCOM_TOKEN auth instructions

### DIFF
--- a/.cursor/agents/jbcom-ecosystem-manager.md
+++ b/.cursor/agents/jbcom-ecosystem-manager.md
@@ -4,6 +4,29 @@ You are the **jbcom Ecosystem Manager**, a specialized Cursor agent for managing
 
 ---
 
+## 🔑 CRITICAL: Authentication
+
+### ALWAYS USE THESE TOKENS:
+```bash
+# For ALL GitHub API/CLI operations on jbcom repos:
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh <command>
+
+# Examples:
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+```
+
+### Token Reference:
+- **GITHUB_JBCOM_TOKEN** - Use for ALL jbcom repo operations (PRs, merges, workflow triggers)
+- **CI_GITHUB_TOKEN** - Used by GitHub Actions workflows (in secrets)
+- **PYPI_TOKEN** - Used by release workflow for PyPI publishing (in secrets)
+
+### ⚠️ NEVER FORGET THIS:
+The default `GH_TOKEN` does NOT have access to jbcom repos. You MUST prefix with `GH_TOKEN="$GITHUB_JBCOM_TOKEN"` for EVERY `gh` command.
+
+---
+
 ## 🏗️ ARCHITECTURE: Monorepo Development
 
 **ALL Python ecosystem code lives in `packages/` in THIS repository.**

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,5 +1,18 @@
 # Cursor AI Rules for Python Library Template
 
+## 🔑 CRITICAL: Authentication (READ FIRST!)
+
+**ALWAYS use `GITHUB_JBCOM_TOKEN` for ALL jbcom repo operations:**
+```bash
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+```
+
+The default `GH_TOKEN` does NOT have jbcom access. NEVER use bare `gh` commands.
+
+---
+
 ## Project Overview
 This is a Python library template using CalVer auto-versioning and automated PyPI releases.
 


### PR DESCRIPTION
CRITICAL: Documents that all gh commands must use GH_TOKEN="$GITHUB_JBCOM_TOKEN"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add critical authentication instructions requiring GH_TOKEN="$GITHUB_JBCOM_TOKEN" for all gh operations, with examples and token references, in agent and rules docs.
> 
> - **Docs**:
>   - **Authentication guidelines** in `.cursor/agents/jbcom-ecosystem-manager.md` and `.cursorrules`:
>     - Require prefixing all `gh` commands with `GH_TOKEN="$GITHUB_JBCOM_TOKEN"`.
>     - Add usage examples and token references; warn default `GH_TOKEN` lacks jbcom access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75bd2e3c6d0d1d364d145bfd65bc80a7f2140bf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->