### PR TITLE
docs: Add GITHUB_JBCOM_TOKEN to ruler source files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,24 @@
 
 **This is the DEFINITIVE Python library template** for the jbcom ecosystem. All configuration, workflows, and agent instructions here represent the consolidated best practices from multiple production deployments.
 
+## 🔑 CRITICAL: Authentication (READ FIRST!)
+
+**ALWAYS use `GITHUB_JBCOM_TOKEN` for ALL jbcom repo operations:**
+```bash
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh workflow run "Release" --repo jbcom/jbcom-control-center
+```
+
+### Token Reference:
+- **GITHUB_JBCOM_TOKEN** - Use for ALL jbcom repo operations (PRs, merges, workflow triggers)
+- **CI_GITHUB_TOKEN** - Used by GitHub Actions workflows (in repo secrets)
+- **PYPI_TOKEN** - Used by release workflow for PyPI publishing (in repo secrets)
+
+### ⚠️ NEVER FORGET:
+The default `GH_TOKEN` does NOT have access to jbcom repos. You MUST prefix with `GH_TOKEN="$GITHUB_JBCOM_TOKEN"` for EVERY `gh` command targeting jbcom repos.
+
 ## 🎯 PURPOSE: Agentic Template Repository
 
 This template is designed for:
@@ -668,6 +686,17 @@ def load_file(filepath: str) -> str:
 # Cursor-Specific Agent Configuration
 
 This file contains Cursor AI specific instructions not covered by standard ruler configuration.
+
+## 🔑 CRITICAL: Authentication (READ FIRST!)
+
+**ALWAYS use `GITHUB_JBCOM_TOKEN` for ALL jbcom repo operations:**
+```bash
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+```
+
+The default `GH_TOKEN` does NOT have jbcom access. NEVER use bare `gh` commands for jbcom repos.
 
 ## Background Agent Modes
 

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -2,6 +2,24 @@
 
 **This is the DEFINITIVE Python library template** for the jbcom ecosystem. All configuration, workflows, and agent instructions here represent the consolidated best practices from multiple production deployments.
 
+## 🔑 CRITICAL: Authentication (READ FIRST!)
+
+**ALWAYS use `GITHUB_JBCOM_TOKEN` for ALL jbcom repo operations:**
+```bash
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh workflow run "Release" --repo jbcom/jbcom-control-center
+```
+
+### Token Reference:
+- **GITHUB_JBCOM_TOKEN** - Use for ALL jbcom repo operations (PRs, merges, workflow triggers)
+- **CI_GITHUB_TOKEN** - Used by GitHub Actions workflows (in repo secrets)
+- **PYPI_TOKEN** - Used by release workflow for PyPI publishing (in repo secrets)
+
+### ⚠️ NEVER FORGET:
+The default `GH_TOKEN` does NOT have access to jbcom repos. You MUST prefix with `GH_TOKEN="$GITHUB_JBCOM_TOKEN"` for EVERY `gh` command targeting jbcom repos.
+
 ## 🎯 PURPOSE: Agentic Template Repository
 
 This template is designed for:

--- a/.ruler/cursor.md
+++ b/.ruler/cursor.md
@@ -2,6 +2,17 @@
 
 This file contains Cursor AI specific instructions not covered by standard ruler configuration.
 
+## 🔑 CRITICAL: Authentication (READ FIRST!)
+
+**ALWAYS use `GITHUB_JBCOM_TOKEN` for ALL jbcom repo operations:**
+```bash
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+```
+
+The default `GH_TOKEN` does NOT have jbcom access. NEVER use bare `gh` commands for jbcom repos.
+
 ## Background Agent Modes
 
 ### Code Review Mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,24 @@
 
 **This is the DEFINITIVE Python library template** for the jbcom ecosystem. All configuration, workflows, and agent instructions here represent the consolidated best practices from multiple production deployments.
 
+## 🔑 CRITICAL: Authentication (READ FIRST!)
+
+**ALWAYS use `GITHUB_JBCOM_TOKEN` for ALL jbcom repo operations:**
+```bash
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh workflow run "Release" --repo jbcom/jbcom-control-center
+```
+
+### Token Reference:
+- **GITHUB_JBCOM_TOKEN** - Use for ALL jbcom repo operations (PRs, merges, workflow triggers)
+- **CI_GITHUB_TOKEN** - Used by GitHub Actions workflows (in repo secrets)
+- **PYPI_TOKEN** - Used by release workflow for PyPI publishing (in repo secrets)
+
+### ⚠️ NEVER FORGET:
+The default `GH_TOKEN` does NOT have access to jbcom repos. You MUST prefix with `GH_TOKEN="$GITHUB_JBCOM_TOKEN"` for EVERY `gh` command targeting jbcom repos.
+
 ## 🎯 PURPOSE: Agentic Template Repository
 
 This template is designed for:
@@ -668,6 +686,17 @@ def load_file(filepath: str) -> str:
 # Cursor-Specific Agent Configuration
 
 This file contains Cursor AI specific instructions not covered by standard ruler configuration.
+
+## 🔑 CRITICAL: Authentication (READ FIRST!)
+
+**ALWAYS use `GITHUB_JBCOM_TOKEN` for ALL jbcom repo operations:**
+```bash
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr create --title "..." --body "..."
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge 123 --squash --delete-branch
+GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh run list --repo jbcom/extended-data-types
+```
+
+The default `GH_TOKEN` does NOT have jbcom access. NEVER use bare `gh` commands for jbcom repos.
 
 ## Background Agent Modes
 


### PR DESCRIPTION
Updated .ruler/ with auth token instructions. Ran ruler apply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GITHUB_JBCOM_TOKEN authentication instructions across agent docs and regenerates generated files via Ruler.
> 
> - **Documentation**:
>   - **Core guidelines**: Add "Authentication" section in `.ruler/AGENTS.md` with required use of `GITHUB_JBCOM_TOKEN`, token reference, and warning about default `GH_TOKEN`; Ruler-regenerated into `AGENTS.md` and `.github/copilot-instructions.md`.
>   - **Cursor config**: Add identical auth guidance to `.ruler/cursor.md`; propagated to Cursor sections in generated docs.
>   - Include concrete `gh` command examples prefixed with `GH_TOKEN="$GITHUB_JBCOM_TOKEN"` and notes on workflows and repo access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d1fc2b5effc99a2d61cd3eeed19bea00dff8ea1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->