### PR TITLE
Investigate sync job and guard failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
   # SYNC TO PUBLIC REPOS (main only)
   # ============================================
   sync:
-    needs: [matrix, test, lint]
+    needs: [matrix, test, lint, enforce]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-enforce-standards.yml
+++ b/.github/workflows/reusable-enforce-standards.yml
@@ -144,24 +144,24 @@ jobs:
           for wf in $WORKFLOWS; do
             SHA=$(gh api repos/$REPO/contents/.github/workflows/$wf --jq '.sha')
             gh api repos/$REPO/contents/.github/workflows/$wf -X DELETE \
-              -f message="🧹 Remove workflow (managed by control-center)" \
+              -f message="Remove workflow (managed by control-center)" \
               -f sha="$SHA" 2>/dev/null || true
             echo "  Deleted .github/workflows/$wf"
           done
           
           # Delete CODEOWNERS
-          SHA=$(gh api repos/$REPO/contents/.github/CODEOWNERS --jq '.sha' 2>/dev/null)
+          SHA=$(gh api repos/$REPO/contents/.github/CODEOWNERS --jq '.sha' 2>/dev/null || echo "")
           if [ -n "$SHA" ]; then
             gh api repos/$REPO/contents/.github/CODEOWNERS -X DELETE \
-              -f message="🧹 Remove CODEOWNERS (managed by control-center)" \
+              -f message="Remove CODEOWNERS (managed by control-center)" \
               -f sha="$SHA" 2>/dev/null || true
           fi
           
           # Delete dependabot.yml (managed centrally)
-          SHA=$(gh api repos/$REPO/contents/.github/dependabot.yml --jq '.sha' 2>/dev/null)
+          SHA=$(gh api repos/$REPO/contents/.github/dependabot.yml --jq '.sha' 2>/dev/null || echo "")
           if [ -n "$SHA" ]; then
             gh api repos/$REPO/contents/.github/dependabot.yml -X DELETE \
-              -f message="🧹 Remove dependabot.yml (managed by control-center)" \
+              -f message="Remove dependabot.yml (managed by control-center)" \
               -f sha="$SHA" 2>/dev/null || true
           fi
 


### PR DESCRIPTION
# Fix: Prevent Sync Jobs on Enforcement Failure & Resolve Enforcement Guard Errors

## Description

This PR addresses two critical issues identified in the CI workflow:

1.  **Sync Jobs Running Despite Failing Enforcement Guards**: The `sync` job was not dependent on the `enforce` job, allowing sync operations to proceed even when enforcement standards failed. This has been corrected by adding `enforce` as a required dependency for `sync`.
2.  **Enforcement Guards Failing at "Remove prohibited files"**: The `reusable-enforce-standards.yml` workflow failed when attempting to remove `CODEOWNERS` or `dependabot.yml` if these files did not exist. This was due to `gh api` returning an exit code 1 (file not found) without proper error handling (`|| echo ""`), causing the script to terminate prematurely. The `|| echo ""` fallback has been added to gracefully handle missing files.

Additionally, emoji characters (🧹) have been removed from commit messages within the `reusable-enforce-standards.yml` to prevent potential encoding issues.

Fixes # (issue)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How has this been tested?

The changes were verified by analyzing the workflow dependency chain and reviewing detailed job logs to identify the root causes of the failures. The fixes directly address the identified logic flaws and error handling deficiencies. The ultimate test will be successful execution of the CI workflow with these changes.

-   [ ] Test A
-   [ ] Test B

**Test Configuration**:

-   Firmware version: N/A
-   Hardware: N/A
-   Toolchain: N/A
-   SDK: N/A

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas (N/A for YAML/shell script changes)
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works (N/A, CI/CD changes are self-testing)
-   [x] New and existing unit tests pass locally with my changes (N/A, no unit tests affected)
-   [ ] Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-4fdd1a35-e70a-4b1e-834b-78a4703e3092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4fdd1a35-e70a-4b1e-834b-78a4703e3092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `sync` depend on `enforce` and improve enforcement cleanup to handle missing files and use ASCII-only messages.
> 
> - **CI/CD**:
>   - Gate `jobs.sync` on `enforce` in `.github/workflows/ci.yml` to block sync when enforcement fails.
> - **Enforcement Workflow** (`.github/workflows/reusable-enforce-standards.yml`):
>   - Harden cleanup: add `|| echo ""` fallbacks when fetching SHAs for `CODEOWNERS` and `dependabot.yml` to avoid failures if absent.
>   - Standardize delete commit messages by removing emoji and using plain ASCII.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a481cbfaddd5bc94fc647ab4a24f68dfaf08eea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->