### PR TITLE
Fix: pycalver needs setuptools, enforce workflow 404 handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install pycalver
-        run: pip install pycalver
+        run: pip install setuptools pycalver
 
       - name: Bump version with pycalver
         id: bump

--- a/.github/workflows/reusable-enforce-standards.yml
+++ b/.github/workflows/reusable-enforce-standards.yml
@@ -137,6 +137,7 @@ jobs:
           GH_TOKEN: ${{ secrets.token }}
           REPO: ${{ inputs.repo }}
         run: |
+          set +e  # Don't exit on error - we handle errors explicitly
           echo "=== Cleanup Prohibited Files ==="
           
           # Helper function to safely delete a file from a repo
@@ -144,13 +145,13 @@ jobs:
             local FILE_PATH="$1"
             local MESSAGE="$2"
             
-            # Get file SHA, suppress all errors
-            SHA=$(gh api "repos/$REPO/contents/$FILE_PATH" --jq '.sha' 2>/dev/null) || true
+            # Get file SHA using subshell to fully suppress errors
+            SHA=$(gh api "repos/$REPO/contents/$FILE_PATH" --jq '.sha' 2>&1 | grep -v "Not Found" | grep -v "404" || echo "")
             
-            if [ -n "$SHA" ] && [ "$SHA" != "null" ]; then
+            if [ -n "$SHA" ] && [ "$SHA" != "null" ] && [ ${#SHA} -eq 40 ]; then
               if gh api "repos/$REPO/contents/$FILE_PATH" -X DELETE \
                 -f message="$MESSAGE" \
-                -f sha="$SHA" 2>/dev/null; then
+                -f sha="$SHA" >/dev/null 2>&1; then
                 echo "  ✓ Deleted $FILE_PATH"
               else
                 echo "  ⚠ Could not delete $FILE_PATH (may need manual removal)"
@@ -159,11 +160,12 @@ jobs:
           }
           
           # Delete workflows (we don't want any in public repos)
-          # Check if .github/workflows directory exists first
-          if gh api "repos/$REPO/contents/.github/workflows" --jq '.[].name' 2>/dev/null > /tmp/workflows.txt; then
-            while IFS= read -r wf; do
+          # Check if .github/workflows directory exists first (using subshell)
+          WORKFLOWS=$(gh api "repos/$REPO/contents/.github/workflows" --jq '.[].name' 2>&1 | grep -v "Not Found" | grep -v "404" || echo "")
+          if [ -n "$WORKFLOWS" ]; then
+            echo "$WORKFLOWS" | while IFS= read -r wf; do
               [ -n "$wf" ] && delete_file ".github/workflows/$wf" "Remove workflow (managed by control-center)"
-            done < /tmp/workflows.txt
+            done
           else
             echo "  No workflows directory found (OK)"
           fi


### PR DESCRIPTION
## Summary
Fixes two CI issues:

1. **Version job fails**: pycalver uses `pkg_resources` which requires setuptools
2. **Enforce job fails with 404**: When public repos don't have .github/workflows directory

## Changes

### ci.yml
- Add `setuptools` to pycalver installation

### reusable-enforce-standards.yml
- Use `set +e` to prevent exit on error
- Filter out 'Not Found' and '404' from gh CLI output using grep
- Validate SHA is exactly 40 characters before attempting delete

## Test Plan
- [ ] CI runs on this PR pass
- [ ] After merge, main branch CI passes the version step
- [ ] After merge, enforce job completes without 404 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Install setuptools for pycalver in version job and make enforce-standards cleanup resilient to missing files/404s.
> 
> - **Workflows**:
>   - **`ci.yml`**: Install `setuptools` alongside `pycalver` for the version bump step.
>   - **`reusable-enforce-standards.yml`**:
>     - Add `set +e` and suppress `gh` errors; filter out `Not Found`/`404` from outputs.
>     - Validate file `sha` length is 40 before deletion; silence DELETE output.
>     - Robustly list and delete `.github/workflows/*` when present; handle missing directory gracefully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a690e5b0e5bf825b8d2f764483b524916a3c793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->