### PR TITLE
Fix: Use uvx pycalver instead of uv run pycalver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,6 @@ jobs:
 
       - uses: astral-sh/setup-uv@v4
 
-      - name: Sync workspace (installs pycalver as dev dependency)
-        run: uv sync --dev
-
       - name: Bump version with pycalver
         id: bump
         run: |
@@ -97,8 +94,8 @@ jobs:
           echo "Current version:"
           grep 'current_version' pyproject.toml | head -1
           
-          # Bump to new version (config has commit=false, tag=false, push=false)
-          uv run pycalver bump --release final
+          # Bump to new version using uvx (config has commit=false, tag=false, push=false)
+          uvx pycalver bump --release final
           
           # Extract new version
           NEW_VERSION=$(grep 'current_version' pyproject.toml | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')


### PR DESCRIPTION
## Summary
`uv run pycalver` tries to run a script from the project, not an installed tool.
`uvx pycalver` is the correct way to run external tools.

Also removes the unnecessary `uv sync --dev` step since uvx handles this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches version bump to `uvx pycalver` and removes unnecessary `uv sync --dev` in the CI version job.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **Version job**:
>     - Replace `uv run pycalver bump --release final` with `uvx pycalver bump --release final`.
>     - Remove prior `uv sync --dev` step.
>     - Update step comments accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a714d48358a9518c4248b903fe558f59d6ae34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->