### PR TITLE
Fix: pycalver requires setuptools for pkg_resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,8 @@ jobs:
           grep 'current_version' pyproject.toml | head -1
           
           # Bump to new version using uvx (config has commit=false, tag=false, push=false)
-          uvx pycalver bump --release final
+          # pycalver requires setuptools for pkg_resources
+          uvx --with setuptools pycalver bump --release final
           
           # Extract new version
           NEW_VERSION=$(grep 'current_version' pyproject.toml | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/')


### PR DESCRIPTION
## Summary
pycalver uses pkg_resources which is in setuptools.
uvx runs in an isolated environment, so we need to explicitly include setuptools.

Uses `uvx --with setuptools pycalver` to include setuptools in the isolated environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modify CI version bump step to run pycalver via `uvx --with setuptools` so `pkg_resources` is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c527e79b8c6a37b2ae5b670e947f7d5ea832c707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->