### PR TITLE
Fix: Align pycalver version format and package versions

### DIFF
--- a/packages/directed-inputs-class/src/directed_inputs_class/__init__.py
+++ b/packages/directed-inputs-class/src/directed_inputs_class/__init__.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 from .__main__ import DirectedInputsClass
 
 
-__version__ = "2025.11.0"
+__version__ = "2025.11.1"
 
 __all__ = ["DirectedInputsClass"]

--- a/packages/extended-data-types/src/extended_data_types/__init__.py
+++ b/packages/extended-data-types/src/extended_data_types/__init__.py
@@ -87,7 +87,7 @@ from .type_utils import (
 from .yaml_utils import decode_yaml, encode_yaml, is_yaml_data
 
 
-__version__ = "2025.11.0"
+__version__ = "2025.11.1"
 
 __all__ = [
     "FilePath",

--- a/packages/lifecyclelogging/src/lifecyclelogging/__init__.py
+++ b/packages/lifecyclelogging/src/lifecyclelogging/__init__.py
@@ -4,7 +4,7 @@ This package provides utilities for managing application lifecycle logs, includi
 configurable logging for console and file outputs.
 """
 
-__version__ = "0.1.3"
+__version__ = "2025.11.1"
 
 from .logging import Logging
 

--- a/packages/vendor-connectors/src/vendor_connectors/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/__init__.py
@@ -1,6 +1,6 @@
 """Vendor Connectors - Universal vendor connectors for the jbcom ecosystem."""
 
-__version__ = "0.1.0"
+__version__ = "2025.11.1"
 
 from vendor_connectors.aws import AWSConnector
 from vendor_connectors.connectors import VendorConnectors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ reportUnknownArgumentType = false
 
 # PyCalVer - workspace-level versioning for all packages
 [pycalver]
-current_version = "202511.0001"
+current_version = "v202511.0001"
 version_pattern = "{pycalver}"
 commit = false
 tag = false
@@ -211,7 +211,7 @@ push = false
 
 [pycalver.file_patterns]
 "pyproject.toml" = [
-    'current_version = "{pep440_version}"',
+    'current_version = "{pycalver}"',
 ]
 "packages/extended-data-types/src/extended_data_types/__init__.py" = [
     '__version__ = "{pep440_version}"',


### PR DESCRIPTION
## Summary
Fixes the pycalver configuration to work properly.

## Changes
- Add leading `v` to `current_version` (required by pycalver's `{pycalver}` pattern)
- Fix file_patterns in pyproject.toml to use `{pycalver}` format for self-reference  
- Align all package `__version__` to `2025.11.1` (the pep440 equivalent of `v202511.0001`)

## Root Cause
pycalver's `{pycalver}` pattern expects versions like `v202511.0001` (with leading `v`), but we had `202511.0001` which caused a PatternError.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Align pycalver config to v-prefixed format and bump package versions to 2025.11.1.
> 
> - **Build/Versioning (pycalver)**:
>   - Set `current_version` to `v202511.0001` and `version_pattern` to `{pycalver}` in `pyproject.toml`.
>   - Update `pycalver.file_patterns` to use `{pycalver}` for `pyproject.toml` and include `packages/vendor-connectors/.../__init__.py`.
> - **Package versions**:
>   - Bump `__version__` to `2025.11.1` in:
>     - `packages/directed-inputs-class/.../__init__.py`
>     - `packages/extended-data-types/.../__init__.py`
>     - `packages/lifecyclelogging/.../__init__.py`
>     - `packages/vendor-connectors/.../__init__.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 648456a35452733ae3c6544c14dc48c518692aea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->