### PR TITLE
Fix: Use correct pycalver placeholder and version format

### DIFF
--- a/packages/directed-inputs-class/src/directed_inputs_class/__init__.py
+++ b/packages/directed-inputs-class/src/directed_inputs_class/__init__.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 from .__main__ import DirectedInputsClass
 
 
-__version__ = "2025.11.1"
+__version__ = "202511.1"
 
 __all__ = ["DirectedInputsClass"]

--- a/packages/extended-data-types/src/extended_data_types/__init__.py
+++ b/packages/extended-data-types/src/extended_data_types/__init__.py
@@ -87,7 +87,7 @@ from .type_utils import (
 from .yaml_utils import decode_yaml, encode_yaml, is_yaml_data
 
 
-__version__ = "2025.11.1"
+__version__ = "202511.1"
 
 __all__ = [
     "FilePath",

--- a/packages/lifecyclelogging/src/lifecyclelogging/__init__.py
+++ b/packages/lifecyclelogging/src/lifecyclelogging/__init__.py
@@ -4,7 +4,7 @@ This package provides utilities for managing application lifecycle logs, includi
 configurable logging for console and file outputs.
 """
 
-__version__ = "2025.11.1"
+__version__ = "202511.1"
 
 from .logging import Logging
 

--- a/packages/vendor-connectors/src/vendor_connectors/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/__init__.py
@@ -1,6 +1,6 @@
 """Vendor Connectors - Universal vendor connectors for the jbcom ecosystem."""
 
-__version__ = "2025.11.1"
+__version__ = "202511.1"
 
 from vendor_connectors.aws import AWSConnector
 from vendor_connectors.connectors import VendorConnectors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,14 +214,14 @@ push = false
     'current_version = "{pycalver}"',
 ]
 "packages/extended-data-types/src/extended_data_types/__init__.py" = [
-    '__version__ = "{pep440_version}"',
+    '__version__ = "{pep440_pycalver}"',
 ]
 "packages/lifecyclelogging/src/lifecyclelogging/__init__.py" = [
-    '__version__ = "{pep440_version}"',
+    '__version__ = "{pep440_pycalver}"',
 ]
 "packages/directed-inputs-class/src/directed_inputs_class/__init__.py" = [
-    '__version__ = "{pep440_version}"',
+    '__version__ = "{pep440_pycalver}"',
 ]
 "packages/vendor-connectors/src/vendor_connectors/__init__.py" = [
-    '__version__ = "{pep440_version}"',
+    '__version__ = "{pep440_pycalver}"',
 ]


### PR DESCRIPTION
## Summary
Fixes the pycalver file pattern configuration.

## Changes
- Use `{pep440_pycalver}` instead of `{pep440_version}` (which doesn't exist in pycalver)
- Update package versions to `202511.1` format (which matches pep440_pycalver)

## Format
- `{pycalver}` = `v202511.0001` (full pycalver format)
- `{pep440_pycalver}` = `202511.1` (PEP 440 compatible, yearmonth.build)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch pycalver patterns to `{pep440_pycalver}` and align package `__version__` values to `202511.1`.
> 
> - **Config**:
>   - Update `pyproject.toml` `pycalver.file_patterns` to use `{pep440_pycalver}` for:
>     - `packages/extended-data-types/src/extended_data_types/__init__.py`
>     - `packages/lifecyclelogging/src/lifecyclelogging/__init__.py`
>     - `packages/directed-inputs-class/src/directed_inputs_class/__init__.py`
>     - `packages/vendor-connectors/src/vendor_connectors/__init__.py`
> - **Packages**:
>   - Normalize `__version__` to PEP 440 calver `"202511.1"` in:
>     - `extended_data_types/__init__.py`
>     - `lifecyclelogging/__init__.py`
>     - `directed_inputs_class/__init__.py`
>     - `vendor_connectors/__init__.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59be6680eaf160443b38b9c3a3e065d3301b9505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->