### PR TITLE
Fix: Build package from workspace root

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Build package
         run: |
-          cd source/packages/${{ inputs.package }}
-          uv build
+          cd source
+          uv build --package ${{ inputs.package }}
           
           # Show what was built
           echo "=== Built artifacts ==="
@@ -54,7 +54,7 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.pypi-token }}
         run: |
-          cd source/packages/${{ inputs.package }}
+          cd source
           
           # uv publish with --skip-existing is not available, but we can handle errors
           uv publish || echo "Package may already exist on PyPI (this is OK)"


### PR DESCRIPTION
## Summary
`uv build` in a workspace outputs to the workspace root's `dist/` folder, not the package's `dist/` folder.

Use `uv build --package <name>` from the workspace root to correctly build and find the artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Build and publish Python packages from the workspace root using `uv --package`, aligning artifacts to the root `dist/`.
> 
> - **CI/CD (GitHub Actions)**:
>   - **Build**: Run `uv build --package ${{ inputs.package }}` from `source/` (workspace root) instead of `source/packages/<pkg>`.
>   - **Publish**: Run `uv publish` from `source/` to publish built artifacts.
>   - **Artifacts**: Listing expects outputs in root `dist/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 385d864aa53cc5629ac730cd701b3e271e8755a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->