### PR TITLE
Fix: Docs workflow issues

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -36,11 +36,15 @@ jobs:
           
           echo "=== Building docs for ${{ inputs.package }} v${{ inputs.version }} ==="
           
-          # Sync workspace with docs dependencies
+          # Sync workspace - try with docs extra, fall back to base if not defined
           cd source
-          uv sync --package ${{ inputs.package }} --extra docs
+          if ! uv sync --package ${{ inputs.package }} --extra docs 2>/dev/null; then
+            echo "Note: docs extra not defined, using base dependencies"
+            uv sync --package ${{ inputs.package }}
+          fi
           
           # Ensure docs/_build directory exists
+          cd ..
           mkdir -p "$PKG_DIR/docs/_build"
           
           # Build if docs source exists
@@ -75,8 +79,8 @@ jobs:
             cd ..
           fi
           
-          # Clear and copy new docs
-          rm -rf gh-pages/* gh-pages/.* 2>/dev/null || true
+          # Clear old docs (preserve .git directory)
+          find gh-pages -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} + 2>/dev/null || true
           
           if [ -d "$PKG_DIR/docs/_build" ]; then
             cp -r "$PKG_DIR/docs/_build/"* gh-pages/ 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Handle packages without `docs` extra defined - fall back to base dependencies
- Preserve `.git` directory when clearing gh-pages content (was causing "fatal: not in a git directory" error)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, docs jobs should pass on main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make docs build fall back when `docs` extra is missing and preserve `.git` when clearing `gh-pages` during deploy.
> 
> - **CI / Docs Workflow (`.github/workflows/reusable-docs.yml`)**:
>   - Build: Try `uv sync --extra docs`; if unavailable, fall back to `uv sync` with base deps. Adjusted directory flow (`cd source` → fallback → `cd ..`) and ensured `docs/_build` creation.
>   - Deploy: Replace blanket removal with selective cleanup to preserve `gh-pages/.git` using `find`.
>   - Minor: Clarified comments and messages during build/deploy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 959d299db53e5fd95e1af64be07f949d1c5f3470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->