### PR TITLE
Fix: Use vendor-connectors as PyPI name

### DIFF
--- a/.cursor/agents/jbcom-ecosystem-manager.md
+++ b/.cursor/agents/jbcom-ecosystem-manager.md
@@ -37,7 +37,7 @@ jbcom-control-center/
 │   ├── extended-data-types/    ← Foundation library (PyPI: extended-data-types)
 │   ├── lifecyclelogging/       ← Logging library (PyPI: lifecyclelogging)
 │   ├── directed-inputs-class/  ← Input processing (PyPI: directed-inputs-class)
-│   └── vendor-connectors/      ← Cloud connectors (PyPI: cloud-connectors)
+│   └── vendor-connectors/      ← Cloud connectors (PyPI: vendor-connectors)
 ├── packages/ECOSYSTEM.toml     ← Single source of truth
 ├── .github/sync.yml            ← Sync configuration
 └── .github/workflows/sync-packages.yml
@@ -203,7 +203,7 @@ done
 pip index versions extended-data-types
 pip index versions lifecyclelogging
 pip index versions directed-inputs-class
-pip index versions cloud-connectors
+pip index versions vendor-connectors
 ```
 
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -978,7 +978,7 @@ Declarative input validation and processing.
 
 ### 4. vendor-connectors
 **Location:** `packages/vendor-connectors/`
-**PyPI:** `cloud-connectors`
+**PyPI:** `vendor-connectors`
 **Public Repo:** `jbcom/vendor-connectors`
 
 Unified cloud provider connectors (AWS, GCP, GitHub, Slack, Vault, Zoom).
@@ -1105,7 +1105,7 @@ done
 ```bash
 pip index versions extended-data-types
 pip index versions lifecyclelogging
-pip index versions cloud-connectors
+pip index versions vendor-connectors
 ```
 
 ### Trigger Manual Sync

--- a/.github/copilot/agents/release-coordinator.agent.yaml
+++ b/.github/copilot/agents/release-coordinator.agent.yaml
@@ -121,7 +121,7 @@ system_prompt: |
     10:35 - PyPI: directed-inputs-class available
     10:40 - Update vendor-connectors
     10:45 - Merge vendor-connectors PR
-    10:50 - PyPI: cloud-connectors available
+    10:50 - PyPI: vendor-connectors available
     11:00 - All game repos can now use new features
   ```
 

--- a/.github/copilot/agents/vendor-connectors-consolidator.agent.yaml
+++ b/.github/copilot/agents/vendor-connectors-consolidator.agent.yaml
@@ -139,7 +139,7 @@ system_prompt: |
 
   ### TypeScript
   ```typescript
-  import { MeshyClient } from '@jbcom/cloud-connectors';
+  import { MeshyClient } from '@jbcom/vendor-connectors';
 
   const client = new MeshyClient({ apiKey: '...' });
   const result = await client.generate3dModel({ prompt: '...' });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - id: set
         run: |
           # Package definitions - single line for GITHUB_OUTPUT compatibility
-          PACKAGES='[{"name":"extended-data-types","pypi":"extended-data-types","repo":"jbcom/extended-data-types","deps":[]},{"name":"lifecyclelogging","pypi":"lifecyclelogging","repo":"jbcom/lifecyclelogging","deps":["extended-data-types"]},{"name":"directed-inputs-class","pypi":"directed-inputs-class","repo":"jbcom/directed-inputs-class","deps":["extended-data-types"]},{"name":"vendor-connectors","pypi":"cloud-connectors","repo":"jbcom/vendor-connectors","deps":["extended-data-types","lifecyclelogging"]}]'
+          PACKAGES='[{"name":"extended-data-types","pypi":"extended-data-types","repo":"jbcom/extended-data-types","deps":[]},{"name":"lifecyclelogging","pypi":"lifecyclelogging","repo":"jbcom/lifecyclelogging","deps":["extended-data-types"]},{"name":"directed-inputs-class","pypi":"directed-inputs-class","repo":"jbcom/directed-inputs-class","deps":["extended-data-types"]},{"name":"vendor-connectors","pypi":"vendor-connectors","repo":"jbcom/vendor-connectors","deps":["extended-data-types","lifecyclelogging"]}]'
           
           PYTHON_VERSIONS='["3.9","3.13"]'
           

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -978,7 +978,7 @@ Declarative input validation and processing.
 
 ### 4. vendor-connectors
 **Location:** `packages/vendor-connectors/`
-**PyPI:** `cloud-connectors`
+**PyPI:** `vendor-connectors`
 **Public Repo:** `jbcom/vendor-connectors`
 
 Unified cloud provider connectors (AWS, GCP, GitHub, Slack, Vault, Zoom).
@@ -1105,7 +1105,7 @@ done
 ```bash
 pip index versions extended-data-types
 pip index versions lifecyclelogging
-pip index versions cloud-connectors
+pip index versions vendor-connectors
 ```
 
 ### Trigger Manual Sync

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ packages/
 ├── extended-data-types/    → PyPI: extended-data-types
 ├── lifecyclelogging/       → PyPI: lifecyclelogging
 ├── directed-inputs-class/  → PyPI: directed-inputs-class
-└── vendor-connectors/      → PyPI: cloud-connectors
+└── vendor-connectors/      → PyPI: vendor-connectors
 ```
 
 ## How It Works
@@ -73,7 +73,7 @@ GH_TOKEN="$GITHUB_JBCOM_TOKEN" gh pr merge ...
 | extended-data-types | [extended-data-types](https://pypi.org/project/extended-data-types/) | Foundation utilities |
 | lifecyclelogging | [lifecyclelogging](https://pypi.org/project/lifecyclelogging/) | Structured logging |
 | directed-inputs-class | [directed-inputs-class](https://pypi.org/project/directed-inputs-class/) | Input validation |
-| vendor-connectors | [cloud-connectors](https://pypi.org/project/cloud-connectors/) | Cloud integrations |
+| vendor-connectors | [vendor-connectors](https://pypi.org/project/vendor-connectors/) | Cloud integrations |
 
 ## Dependency Order
 

--- a/packages/ECOSYSTEM.toml
+++ b/packages/ECOSYSTEM.toml
@@ -53,7 +53,7 @@ dependents = []
 
 [packages.vendor-connectors]
 path = "packages/vendor-connectors"
-pypi_name = "cloud-connectors"
+pypi_name = "vendor-connectors"
 public_repo = "jbcom/vendor-connectors"
 role = "integrations"
 description = "Unified cloud provider connectors"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ members = ["packages/*"]
 extended-data-types = { workspace = true }
 lifecyclelogging = { workspace = true }
 directed-inputs-class = { workspace = true }
-cloud-connectors = { workspace = true }
+vendor-connectors = { workspace = true }
 
 [project]
 name = "jbcom-control-center"

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 
 [manifest]
 members = [
-    "cloud-connectors",
+    "vendor-connectors",
     "directed-inputs-class",
     "extended-data-types",
     "jbcom-control-center",
@@ -478,7 +478,7 @@ wheels = [
 ]
 
 [[package]]
-name = "cloud-connectors"
+name = "vendor-connectors"
 source = { editable = "packages/vendor-connectors" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- Changed PyPI package name for vendor-connectors from `cloud-connectors` to `vendor-connectors`
- Aligns with the actual package name defined in `packages/vendor-connectors/pyproject.toml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the PyPI package name for `vendor-connectors` in the CI release matrix.
> 
> - **CI workflow (`.github/workflows/ci.yml`)**:
>   - Corrects `pypi` name for `vendor-connectors` in `PACKAGES` matrix from `cloud-connectors` to `vendor-connectors`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b47d6d78e4b7f099fed69095c594d323a3bec202. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->