### PR TITLE
Add aider CLI with Python 3.12 workaround

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -66,5 +66,5 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/F1bonacc1/process-comp
 # aider requires Python 3.12 (not 3.13) - use uv's managed Python
 # See: https://github.com/Aider-AI/aider/issues/3037
 ENV PATH="/root/.local/bin:$PATH"
-RUN uv tool install --python python3.12 aider-chat@latest && \
+RUN uv tool install --python python3.12 aider-chat==0.86.1 && \
     aider --version


### PR DESCRIPTION
## Summary
- Adds `aider-chat` to the Dockerfile using uv's managed Python 3.12
- Works around aider's Python 3.13 incompatibility

## Why
aider is required for AI-powered forensic recovery in the agent tooling:
- `.cursor/scripts/agent-recover` uses aider for conversation analysis
- `.cursor/scripts/agent-recover-delegate` delegates to aider for forensic reports
- `docs/AGENTIC-DIFF-RECOVERY.md` documents the aider-based recovery workflow

## Reference
- https://github.com/Aider-AI/aider/issues/3037

## Test plan
- [ ] Docker build succeeds
- [ ] `aider --version` works in container

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Installs aider-chat in the dev container via uv using Python 3.12 and updates PATH, working around Python 3.13 incompatibility.
> 
> - **Docker**:
>   - Add AI CLI tools in `.cursor/Dockerfile`:
>     - Update `PATH` to include `/root/.local/bin`.
>     - Install `aider-chat@latest` via `uv` with `--python python3.12`.
>     - Verify installation with `aider --version`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7514ed346de5815cbc45d0d116e75ae876aa039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->