### PR TITLE
fix: Use JBCOM_TOKEN secret (GitHub disallows GITHUB_ prefix)

### DIFF
--- a/.github/workflows/agentic-cycle.yml
+++ b/.github/workflows/agentic-cycle.yml
@@ -77,7 +77,7 @@ jobs:
       
       - name: Parse cycle and create repo issues
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_TOKEN: ${{ secrets.JBCOM_TOKEN }}
           CYCLE_NUM: ${{ needs.detect-cycle.outputs.cycle_number }}
         run: |
           # Get cycle issue details
@@ -157,7 +157,7 @@ Monitor progress via the links above. Repos will notify back when complete.
     steps:
       - name: Collect status from repos
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_TOKEN: ${{ secrets.JBCOM_TOKEN }}
           CYCLE_NUM: ${{ needs.detect-cycle.outputs.cycle_number }}
         run: |
           echo "Aggregating status for cycle #$CYCLE_NUM..."
@@ -213,7 +213,7 @@ Monitor progress via the links above. Repos will notify back when complete.
     steps:
       - name: Verify and close cycle
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_TOKEN: ${{ secrets.JBCOM_TOKEN }}
           CYCLE_NUM: ${{ needs.detect-cycle.outputs.cycle_number }}
         run: |
           echo "Completing cycle #$CYCLE_NUM..."

--- a/.github/workflows/sync-claude-tooling.yml
+++ b/.github/workflows/sync-claude-tooling.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: ${{ matrix.repo }}
-          token: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          token: ${{ secrets.JBCOM_TOKEN }}
           path: target-repo
       
       - name: Sync Claude tooling
@@ -88,7 +88,7 @@ jobs:
       - name: Create sync PR
         if: steps.sync.outputs.changed == 'true' && inputs.dry_run != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_TOKEN: ${{ secrets.JBCOM_TOKEN }}
         run: |
           cd target-repo
           

--- a/.github/workflows/wiki-manage.yml
+++ b/.github/workflows/wiki-manage.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  pages: write
 
 jobs:
   wiki-init:
@@ -32,7 +33,7 @@ jobs:
       
       - name: Initialize Wiki
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x .cursor/scripts/wiki-cli
           .cursor/scripts/wiki-cli init
@@ -50,7 +51,7 @@ jobs:
       
       - name: Migrate Content
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x .cursor/scripts/wiki-cli
           
@@ -72,8 +73,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          token: ${{ secrets.GITHUB_JBCOM_TOKEN }}
       
       - name: Create Minimal AGENTS.md
         run: |
@@ -91,7 +90,6 @@ jobs:
           ## Critical Rules
 
           - **CalVer versioning** - `YYYY.MM.BUILD`, never manual
-          - **Use GITHUB_JBCOM_TOKEN** - For jbcom repo operations
           - **Read wiki first** - Before making decisions
 
           ## Memory Bank Access
@@ -164,7 +162,6 @@ jobs:
           ## Critical Rules
 
           - CalVer versioning (never manual)
-          - Use GITHUB_JBCOM_TOKEN for jbcom repos
           - Read wiki before making decisions
           - Update wiki after completing work
           EOF
@@ -186,6 +183,8 @@ jobs:
       
       - name: Commit Changes
         if: inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"

--- a/templates/claude/workflows/claude-upstream-notify.yml
+++ b/templates/claude/workflows/claude-upstream-notify.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Notify Control Plane
         if: steps.find_ref.outputs.control_issue != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_JBCOM_TOKEN }}
+          GH_TOKEN: ${{ secrets.JBCOM_TOKEN }}
         run: |
           CONTROL_ISSUE="${{ steps.find_ref.outputs.control_issue }}"
           TYPE="${{ steps.find_ref.outputs.type }}"


### PR DESCRIPTION
GitHub Actions secrets cannot start with GITHUB_ prefix.

- Updated agentic-cycle.yml to use secrets.JBCOM_TOKEN
- Updated sync-claude-tooling.yml to use secrets.JBCOM_TOKEN
- Updated claude-upstream-notify.yml template
- Added JBCOM_TOKEN secret to repo (done)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace GITHUB_JBCOM_TOKEN with JBCOM_TOKEN across workflows, update wiki workflow to use github.token and add pages permission.
> 
> - **CI Workflows**:
>   - **Token updates**: Switch `GH_TOKEN`/checkout tokens from `secrets.GITHUB_JBCOM_TOKEN` to `secrets.JBCOM_TOKEN` in `agentic-cycle.yml`, `sync-claude-tooling.yml`, and `templates/claude/workflows/claude-upstream-notify.yml`.
> - **Wiki Management** (`wiki-manage.yml`):
>   - Permissions: add `pages: write`.
>   - Use `github.token` for `GH_TOKEN` in init/migrate and for commits in cleanup.
>   - Remove custom token from checkout in cleanup.
>   - Generated docs: drop references to using `GITHUB_JBCOM_TOKEN` rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 664cb9b6417664c9edc514c979bf1fc6665c2981. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->