### PR TITLE
perf: Optimize Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   review:
-    # Skip holding PRs and PRs with no-review label
     if: |
       !contains(github.event.pull_request.title, '[HOLDING]') &&
       !contains(github.event.pull_request.labels.*.name, 'no-review') &&
       !contains(github.event.pull_request.labels.*.name, 'no-agent-review')
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # Job timeout, not Claude timeout
     permissions:
       contents: read
       pull-requests: write
@@ -26,55 +26,51 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check if code changes exist
+        id: check
+        run: |
+          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+          echo "Changed files:"
+          echo "$CHANGED"
+          
+          # Skip review for wiki/docs only changes
+          CODE_CHANGES=$(echo "$CHANGED" | grep -vE '^(wiki/|docs/|.*\.md$)' || true)
+          
+          if [ -z "$CODE_CHANGES" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "📝 Only wiki/docs changes"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "🔍 Code changes detected"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Run Claude Code Review
+        if: steps.check.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
-          # Allow bot-initiated PRs (cursor background agents, dependabot, etc.)
-          allowed_bots: "cursor,github-actions[bot],dependabot[bot],amazon-q-developer[bot],gemini-code-assist[bot]"
+          # Use sticky comment to avoid spam
+          use_sticky_comment: true
+          # Allow cursor bot PRs
+          allowed_bots: "cursor,github-actions[bot],dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
-            PR TITLE: ${{ github.event.pull_request.title }}
-            PR AUTHOR: ${{ github.event.pull_request.user.login }}
-            PR BRANCH: ${{ github.event.pull_request.head.ref }}
 
-            Please review this pull request with a focus on:
+            Review this PR for:
+            - Bugs and logic errors
+            - Security issues
+            - Type safety (Python typed project)
+            - Test coverage
 
-            ## Code Quality
-            - Check for bugs, logic errors, and edge cases
-            - Verify type safety (this is a typed Python project)
-            - Review error handling and exceptions
-            - Check for code duplication
-
-            ## Security
-            - Check for credential leaks or hardcoded secrets
-            - Verify input validation
-            - Review any API/network calls for security
-            - Check for command injection in shell scripts
-
-            ## Python Best Practices
-            - Type hints on all public functions (Google style)
-            - Docstrings for public APIs (Google style)
-            - Use of pathlib over os.path
-            - Modern Python patterns (3.9+)
-
-            ## Tests
-            - Verify test coverage for new code
-            - Check test quality and assertions
-            - Look for missing edge case tests
-
-            ## Project Standards
-            - CalVer versioning (YYYY.MM.BUILD)
-            - No manual version management
-            - Ruff for linting, mypy for type checking
-
-            ## Instructions
-            - Use `gh pr comment` for top-level feedback
-            - Use inline comments for specific code issues
-            - Be constructive and helpful
-            - If approving, explain why it's good
-            - If requesting changes, be specific about fixes needed
+            Use `gh pr comment` for summary.
+            Use `mcp__github_inline_comment__create_inline_comment` for specific issues.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
+            --max-turns 10
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep"
+
+      - name: Skip notification
+        if: steps.check.outputs.skip == 'true'
+        run: echo "✅ Skipped - wiki/docs only changes"


### PR DESCRIPTION
## Problem
Claude PR review takes 2-3+ minutes even for wiki/docs only changes.

## Solution
- Skip review for wiki/ and docs/ only PRs
- Add 5 minute timeout
- Shorter, focused prompt  
- Max 10 turns

## Test
Wiki-only PRs should get quick 'skipped' comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips docs/wiki-only PRs and tightens the Claude review action with timeouts, fetch-depth 0, a concise prompt, limited tools, and a max of 10 turns, plus a skip notification comment.
> 
> - **GitHub Actions workflow** (`.github/workflows/claude-pr-review.yml`):
>   - **Skip non-code PRs**: Pre-check filters out `wiki/`, `docs/`, and `*.md`-only changes; posts a "skipped" PR comment.
>   - **Performance/limits**: Add job and action timeouts (5m); switch checkout to `fetch-depth: 0`.
>   - **Review step gating**: Run Claude review only when code changes are detected.
>   - **Action tuning**: Simplify prompt; restrict `claude_args` allowed tools; cap to `--max-turns 10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c18b96dc8f1c772b29762e4350d0fb54264643e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->