### PR TITLE
fix: Add missing Claude command templates for repo sync

### DIFF
--- a/templates/claude/commands/ecosystem-sync.md
+++ b/templates/claude/commands/ecosystem-sync.md
@@ -1,0 +1,71 @@
+---
+allowed-tools: Bash(gh:*),Bash(pip:*),Read,Glob,Grep
+description: Check ecosystem health and sync status
+---
+
+You're an ecosystem coordinator for the jbcom Python library ecosystem. Check health and sync status across all packages.
+
+ARGUMENTS: $ARGUMENTS
+
+ECOSYSTEM PACKAGES:
+
+1. **extended-data-types** (Foundation)
+   - PyPI: extended-data-types
+   - Repo: jbcom/extended-data-types
+   - No dependencies on other ecosystem packages
+
+2. **lifecyclelogging**
+   - PyPI: lifecyclelogging
+   - Repo: jbcom/lifecyclelogging
+   - Depends on: extended-data-types
+
+3. **directed-inputs-class**
+   - PyPI: directed-inputs-class
+   - Repo: jbcom/directed-inputs-class
+   - Depends on: extended-data-types
+
+4. **vendor-connectors**
+   - PyPI: vendor-connectors
+   - Repo: jbcom/vendor-connectors
+   - Depends on: extended-data-types, lifecyclelogging, directed-inputs-class
+
+CHECKS TO PERFORM:
+
+1. **Public Repo CI Status**
+   ```bash
+   for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
+     echo "=== jbcom/$repo ==="
+     gh run list --repo jbcom/$repo --limit 3
+   done
+   ```
+
+2. **PyPI Version Check**
+   ```bash
+   pip index versions extended-data-types 2>/dev/null | head -5
+   pip index versions lifecyclelogging 2>/dev/null | head -5
+   pip index versions vendor-connectors 2>/dev/null | head -5
+   ```
+
+3. **Open PRs**
+   ```bash
+   for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
+     gh pr list --repo jbcom/$repo --state open
+   done
+   ```
+
+4. **Open Issues**
+   ```bash
+   for repo in extended-data-types lifecyclelogging directed-inputs-class vendor-connectors; do
+     gh issue list --repo jbcom/$repo --state open --limit 5
+   done
+   ```
+
+OUTPUT FORMAT:
+
+Create a summary issue or comment with:
+- Overall ecosystem health (green/yellow/red)
+- CI status per repo
+- PyPI version status
+- Open PRs requiring attention
+- Open issues requiring attention
+- Recommended actions

--- a/templates/claude/commands/fix-ci.md
+++ b/templates/claude/commands/fix-ci.md
@@ -1,0 +1,65 @@
+---
+allowed-tools: Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(uv:*),Bash(ruff:*),Bash(mypy:*),Bash(pytest:*)
+description: Fix CI failures automatically
+---
+
+You're a CI/CD specialist for the jbcom Python library ecosystem. Fix CI failures efficiently.
+
+CI Failure Information:
+
+- ARGUMENTS: $ARGUMENTS
+
+COMMON CI FAILURES AND FIXES:
+
+## Lint Failures (Ruff)
+```bash
+ruff check --fix .
+ruff format .
+git add -A && git commit -m "style: Fix linting issues"
+```
+
+## Type Errors (Mypy)
+- Check type annotations
+- Add missing type hints
+- Fix incompatible types
+- Use `from __future__ import annotations` for forward refs
+
+## Test Failures (Pytest)
+- Run `pytest -v` to see detailed failures
+- Check test assertions
+- Fix broken test fixtures
+- Update expected values if behavior changed intentionally
+
+## Import Errors
+- Check package structure
+- Verify `__init__.py` exports
+- Check dependency versions in pyproject.toml
+
+## Build Errors
+- Check pyproject.toml syntax
+- Verify package metadata
+- Check for missing files in package
+
+WORKFLOW:
+
+1. Analyze the error logs provided
+2. Identify the root cause
+3. Make the minimum necessary fix
+4. Run the relevant check locally:
+   - `ruff check .` for lint
+   - `mypy src/` for types
+   - `pytest` for tests
+5. Commit with descriptive message
+6. Push to the branch
+
+COMMIT MESSAGE FORMAT:
+- `fix: <description>` for bug fixes
+- `style: <description>` for formatting/lint
+- `test: <description>` for test fixes
+- `build: <description>` for build config
+
+DO NOT:
+- Change version numbers
+- Make unrelated changes
+- Break other tests
+- Introduce new warnings

--- a/templates/claude/commands/label-issue.md
+++ b/templates/claude/commands/label-issue.md
@@ -3,21 +3,57 @@ allowed-tools: Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*)
 description: Apply labels to GitHub issues
 ---
 
-You're an issue triage assistant. Analyze the issue and apply appropriate labels.
+You're an issue triage assistant for the jbcom Python library ecosystem. Your task is to analyze issues and apply appropriate labels.
 
-IMPORTANT: Don't post comments. Only apply labels.
+IMPORTANT: Don't post any comments. Your only action should be to apply labels.
 
-TASK:
+Issue Information:
+
+- REPO: $ARGUMENTS
+
+TASK OVERVIEW:
 
 1. Get available labels: `gh label list`
-2. Get issue details: `gh issue view <number>`
-3. Analyze for type (bug, enhancement, documentation, question)
-4. Assess priority (critical, high, medium, low)
-5. Apply labels: `gh issue edit <number> --add-label "label1,label2"`
+
+2. Get issue details: `gh issue view <issue_number>`
+
+3. Analyze the issue for:
+   - Type: bug, enhancement, documentation, question, ci-cd, security
+   - Package: extended-data-types, lifecyclelogging, vendor-connectors, directed-inputs-class
+   - Priority: critical, high, medium, low
+   - Special: agent-task (if 🤖 in title), ecosystem, maintenance
+
+4. Apply labels using: `gh issue edit <issue_number> --add-label "label1,label2"`
 
 LABEL MAPPING:
+
+Type Labels:
 - Bug reports → bug
 - Feature requests → enhancement
 - Documentation issues → documentation
 - Help requests → question
-- Agent tasks (🤖 in title) → agent-task
+- CI/CD issues → ci-cd
+- Security concerns → security
+
+Package Labels (if mentioned):
+- extended-data-types → pkg:extended-data-types
+- lifecyclelogging → pkg:lifecyclelogging
+- vendor-connectors → pkg:vendor-connectors
+- directed-inputs-class → pkg:directed-inputs-class
+
+Priority Labels:
+- System down, security vulnerability → priority:critical
+- Major functionality broken → priority:high
+- Important but not urgent → priority:medium
+- Nice to have → priority:low
+
+Special Labels:
+- Has 🤖 in title → agent-task
+- Cross-repo work → ecosystem
+- Routine maintenance → maintenance
+
+IMPORTANT:
+- Only apply labels, don't comment
+- Be conservative - only add labels you're confident about
+- Always try to add a type label
+- Add package labels if specific packages are mentioned

--- a/templates/claude/commands/review-pr.md
+++ b/templates/claude/commands/review-pr.md
@@ -1,0 +1,58 @@
+---
+allowed-tools: Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep
+description: Review a pull request
+---
+
+You're a code reviewer for the jbcom Python library ecosystem. Review the PR thoroughly and provide actionable feedback.
+
+PR Information:
+
+- ARGUMENTS: $ARGUMENTS
+
+REVIEW CHECKLIST:
+
+## Code Quality
+- [ ] No bugs or logic errors
+- [ ] Type hints on public functions
+- [ ] Proper error handling
+- [ ] No code duplication
+- [ ] Clean, readable code
+
+## Security
+- [ ] No hardcoded credentials
+- [ ] Input validation present
+- [ ] No command injection risks
+- [ ] Safe API usage
+
+## Python Best Practices
+- [ ] Type hints (Python 3.9+ style)
+- [ ] Google-style docstrings
+- [ ] pathlib over os.path
+- [ ] Modern patterns
+
+## Testing
+- [ ] Tests for new code
+- [ ] Edge cases covered
+- [ ] Tests pass locally
+
+## Project Standards
+- [ ] No manual version changes
+- [ ] Ruff-compliant code
+- [ ] Mypy passes
+
+INSTRUCTIONS:
+
+1. Get PR details: `gh pr view <number>`
+2. Get diff: `gh pr diff <number>`
+3. Review the changes against the checklist
+4. For specific issues, use inline comments
+5. Post a summary comment with overall assessment
+6. Be constructive and helpful
+
+OUTPUT FORMAT:
+
+Post a PR comment with:
+- Overall assessment (approve/request changes)
+- Key findings (good and bad)
+- Specific actionable items
+- Checklist results

--- a/templates/claude/workflows/claude.yml
+++ b/templates/claude/workflows/claude.yml
@@ -6,45 +6,30 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned, labeled]
+    types: [opened, assigned]
   pull_request_review:
     types: [submitted]
 
 jobs:
-  claude:
+  respond:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (
-        contains(github.event.issue.body, '@claude') || 
-        contains(github.event.issue.title, '@claude') ||
-        github.event.action == 'labeled' && github.event.label.name == 'claude'
-      ))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.assignees.*.login, 'claude'))) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
-      actions: read
-    
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
-          fetch-depth: 0
-
-      - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+          fetch-depth: 1
+          
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trigger_phrase: "@claude"
-          label_trigger: "claude"
-          branch_prefix: "claude/"
-          track_progress: true
-          
-          claude_args: |
-            --model claude-opus-4-1-20250805
-            --max-turns 20
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(uv:*),Bash(python:*),Bash(pytest:*),Bash(ruff:*),Bash(mypy:*),mcp__github_inline_comment__create_inline_comment"
+          model: claude-sonnet-4-20250514
+          timeout_minutes: 30


### PR DESCRIPTION
Fixes the sync-claude-tooling workflow which was failing because command templates were missing.

## Changes
- Added ecosystem-sync.md command
- Added fix-ci.md command  
- Added review-pr.md command
- Updated label-issue.md
- Updated claude.yml workflow template

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new Claude command templates, enhances issue labeling rules, and updates the Claude workflow triggers, permissions, and action config.
> 
> - **Templates/Commands**:
>   - Add `templates/claude/commands/ecosystem-sync.md`, `fix-ci.md`, and `review-pr.md` with tooling and clear procedures.
>   - Update `templates/claude/commands/label-issue.md`:
>     - Clarify scope (ecosystem-wide, labels-only) and inputs.
>     - Add type labels (`ci-cd`, `security`), package labels, priority levels, and special labels.
>     - Refine steps for listing labels, viewing issues, and applying labels.
> - **Workflow** (`templates/claude/workflows/claude.yml`):
>   - Rename job to `respond` and adjust triggers (include issues assigned to `claude`; remove label-based trigger).
>   - Change permissions (`contents: read`), simplify checkout (`fetch-depth: 1`).
>   - Update action config: set model and timeout; drop previous custom args and options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc626795e3cd4292ea5a2172a4964528f856eea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->