### PR TITLE
fix: Use pipe delimiter in sed to handle repo paths with slashes

### DIFF
--- a/.github/workflows/sync-claude-tooling.yml
+++ b/.github/workflows/sync-claude-tooling.yml
@@ -66,8 +66,8 @@ jobs:
           
           # Copy and customize CLAUDE.md
           cp ../control-center/templates/claude/CLAUDE.md.template ./CLAUDE.md
-          sed -i "s/\${PACKAGE_NAME}/$PACKAGE_NAME/g" ./CLAUDE.md
-          sed -i "s/\${REPO}/${{ matrix.repo }}/g" ./CLAUDE.md
+          sed -i "s|\${PACKAGE_NAME}|$PACKAGE_NAME|g" ./CLAUDE.md
+          sed -i "s|\${REPO}|${{ matrix.repo }}|g" ./CLAUDE.md
           
           # Copy commands
           cp ../control-center/templates/claude/commands/*.md ./.claude/commands/


### PR DESCRIPTION
The sed command was failing because repo names contain slashes (e.g., jbcom/extended-data-types) which conflicted with the default / delimiter.

Changed from:
```
sed -i "s/\${REPO}/${{ matrix.repo }}/g"
```

To:
```
sed -i "s|\${REPO}|${{ matrix.repo }}|g"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch sed substitutions to use | as the delimiter to safely replace `PACKAGE_NAME` and `REPO` in CLAUDE.md within the sync workflow.
> 
> - **GitHub Actions** (`.github/workflows/sync-claude-tooling.yml`):
>   - Update `sed` commands to use `|` delimiter when substituting `\${PACKAGE_NAME}` and `\${REPO}` in `CLAUDE.md`, avoiding conflicts with slashes in repo paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c507e923c8c4730d6979cb0cdfdb77a7e8e9ca17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->