### PR TITLE
fix: Detect new untracked files in Claude sync workflow

### DIFF
--- a/.github/workflows/sync-claude-tooling.yml
+++ b/.github/workflows/sync-claude-tooling.yml
@@ -75,14 +75,15 @@ jobs:
           # Copy workflows
           cp ../control-center/templates/claude/workflows/*.yml ./.github/workflows/
           
-          # Check for changes
-          if git diff --quiet && git diff --cached --quiet; then
+          # Check for changes (including untracked files)
+          git add -A
+          if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "No changes to sync for ${{ matrix.repo }}"
           else
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "Changes detected for ${{ matrix.repo }}"
-            git diff --stat
+            git diff --cached --stat
           fi
       
       - name: Create sync PR


### PR DESCRIPTION
The sync workflow was reporting 'no changes' even when copying new files because `git diff` only shows changes in tracked files.

Fixed by staging all files with `git add -A` before checking for changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure the sync workflow detects new files by staging all changes and checking the cached diff.
> 
> - **Workflow** (`.github/workflows/sync-claude-tooling.yml`):
>   - Detect changes including untracked files by running `git add -A` before comparison.
>   - Switch checks from `git diff` to `git diff --cached` (and `--stat`) to use the staged index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f7ec304f8d4d25264b1066e26c4522bc8010aee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->