### PR TITLE
cycle: Update Phase 1 progress - terraform-modules PR created

### DIFF
--- a/.github/cycles/001-control-plane-activation.md
+++ b/.github/cycles/001-control-plane-activation.md
@@ -73,8 +73,7 @@ Fully activate the jbcom control plane for managing the Python library ecosystem
 ### Enterprise (FlipsideCrypto)
 | Repo | Type | Status |
 |------|------|--------|
-| terraform-modules | Consumer | ⏳ Pending integration |
-| (others) | TBD | ⏳ Inventory needed |
+| terraform-modules | Consumer (`extended-data-types`) | 🔄 PR #208 open |
 
 ### Enterprise (fsc-internal-tooling-administration)
 | Repo | Type | Status |
@@ -87,8 +86,10 @@ Fully activate the jbcom control plane for managing the Python library ecosystem
 ## Next Actions
 
 ### Phase 1: Enterprise Integration (This Cycle)
-1. [ ] Inventory FlipsideCrypto repos that use jbcom packages
-2. [ ] Update terraform-modules to use latest package versions
+1. [x] Inventory FlipsideCrypto repos that use jbcom packages
+   - `terraform-modules` uses `extended-data-types` (only consumer found)
+2. [x] Update terraform-modules to use latest package versions
+   - PR #208: https://github.com/FlipsideCrypto/terraform-modules/pull/208
 3. [ ] Document enterprise dependency graph
 4. [ ] Set up Claude tooling in enterprise repos (where appropriate)
 
@@ -184,5 +185,5 @@ Fully activate the jbcom control plane for managing the Python library ecosystem
 
 ---
 
-*Last Updated*: 2025-11-28 04:15 UTC
+*Last Updated*: 2025-11-28 04:40 UTC
 *Cycle Owner*: Background Agent


### PR DESCRIPTION
## Summary
- Marked Phase 1 tasks 1 & 2 as complete
- Created PR #208 in FlipsideCrypto/terraform-modules to update extended-data-types
- Updated repository map with consumer status

## Changes
- Updated .github/cycles/001-control-plane-activation.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks Phase 1 tasks 1–2 complete, documents `terraform-modules` as a consumer of `extended-data-types` with PR #208, and updates the cycle timestamp.
> 
> - **Docs**: Update `.github/cycles/001-control-plane-activation.md`
>   - **Phase 1 Progress**: Mark tasks 1–2 complete; note `terraform-modules` consumes `extended-data-types`; link to PR `#208`.
>   - **Repository Map**: In FlipsideCrypto section, set `terraform-modules` to Consumer (`extended-data-types`) with PR status shown.
>   - **Metadata**: Refresh "Last Updated" timestamp.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb09680bedf151b9a97387a584b5c1d6c239f8e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->