### PR TITLE
fix: Bump versions to 202511.3 to unblock releases

### DIFF
--- a/packages/directed-inputs-class/src/directed_inputs_class/__init__.py
+++ b/packages/directed-inputs-class/src/directed_inputs_class/__init__.py
@@ -9,6 +9,6 @@ from __future__ import annotations
 from .__main__ import DirectedInputsClass
 
 
-__version__ = "202511.1"
+__version__ = "202511.3"
 
 __all__ = ["DirectedInputsClass"]

--- a/packages/extended-data-types/src/extended_data_types/__init__.py
+++ b/packages/extended-data-types/src/extended_data_types/__init__.py
@@ -105,7 +105,7 @@ from .type_utils import (
 from .yaml_utils import decode_yaml, encode_yaml, is_yaml_data
 
 
-__version__ = "202511.1"
+__version__ = "202511.3"
 
 __all__ = [
     "FilePath",

--- a/packages/lifecyclelogging/src/lifecyclelogging/__init__.py
+++ b/packages/lifecyclelogging/src/lifecyclelogging/__init__.py
@@ -4,7 +4,7 @@ This package provides utilities for managing application lifecycle logs, includi
 configurable logging for console and file outputs, and clean exit functionality.
 """
 
-__version__ = "202511.1"
+__version__ = "202511.3"
 
 from .logging import ExitRunError, KeyTransform, Logging
 

--- a/packages/vendor-connectors/src/vendor_connectors/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/__init__.py
@@ -1,6 +1,6 @@
 """Vendor Connectors - Universal vendor connectors for the jbcom ecosystem."""
 
-__version__ = "202511.1"
+__version__ = "202511.3"
 
 from vendor_connectors.aws import AWSConnector
 from vendor_connectors.connectors import VendorConnectors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ reportUnknownArgumentType = false
 
 # PyCalVer - workspace-level versioning for all packages
 [pycalver]
-current_version = "v202511.0001"
+current_version = "v202511.0003"
 version_pattern = "{pycalver}"
 commit = false
 tag = false


### PR DESCRIPTION
## Summary

Manual version bump to unblock package releases after CI workflow bug.

## Problem

The CI workflow at `.github/workflows/ci.yml`:
1. Bumps versions locally (`202511.1` → `202511.2`)
2. Uploads bumped source as artifact
3. Tries to publish to PyPI
4. **Fails** because `202511.2` already exists from a previous run
5. **Never commits** the version bump back to main

This caused PR #206 changes to be merged but never published.

## Solution

Manually bump all package versions to `202511.3`:
- Skip the already-published `202511.2`  
- Allow PR #206 changes (file operations, exit_run) to be released
- Unblock terraform-modules PR #203

## Changes

- `packages/*/src/*/__init__.py`: `__version__ = "202511.3"`
- `pyproject.toml`: `current_version = "v202511.0003"`

## Test Plan

- [ ] CI passes
- [ ] Packages publish to PyPI successfully with version `202511.3`
- [ ] New exports are available: `ExitRunError`, `KeyTransform`, `read_file`, `write_file`, etc.

Fixes #210

---

*Filed by @cursor background agent on terraform-modules PR #203*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `__version__` in four packages to 202511.3 and updates workspace PyCalVer to v202511.0003.
> 
> - **Versions**:
>   - **Packages**: Bump `__version__` to `202511.3` in:
>     - `packages/directed-inputs-class/src/directed_inputs_class/__init__.py`
>     - `packages/extended-data-types/src/extended_data_types/__init__.py`
>     - `packages/lifecyclelogging/src/lifecyclelogging/__init__.py`
>     - `packages/vendor-connectors/src/vendor_connectors/__init__.py`
>   - **Workspace**: Update `pyproject.toml` `pycalver.current_version` from `v202511.0001` to `v202511.0003`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0381f6377f65a01f3dc07a051039b3d81e7eaa69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->