### PR TITLE
fix(ci): Use uv tool install for externally managed Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       - uses: hynek/setup-cached-uv@v2
 
       - name: Install semantic-release
-        run: uv pip install --system python-semantic-release
+        run: uv tool install python-semantic-release
 
       - name: Check version
         id: check


### PR DESCRIPTION
## Summary

Fix CI failure caused by Ubuntu 24.04's externally managed Python (PEP 668).

## Problem

The release job was failing with:
```
error: The interpreter at /usr is externally managed
```

This occurs because `uv pip install --system python-semantic-release` tries to install to the system Python, which is protected on Ubuntu 24.04+.

## Solution

Changed from:
```yaml
run: uv pip install --system python-semantic-release
```

To:
```yaml
run: uv tool install python-semantic-release
```

`uv tool install` creates an isolated environment automatically.

## Impact

This unblocks the entire jbcom ecosystem release chain:
- jbcom-control-center releases → vendor-connectors PyPI
- terraform-modules PR #203 can proceed
- terraform-modules PR #209 can proceed

## Test Plan

- [ ] CI passes
- [ ] Release job succeeds
- [ ] Packages publish to PyPI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the release job to install `python-semantic-release` using `uv tool install` instead of `uv pip install --system`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f8c665fccf5ba6dccd734c78c4b78a1dfaaa312. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->