### PR TITLE
fix(connectors): Trigger vendor-connectors PyPI release

### DIFF
--- a/packages/vendor-connectors/README.md
+++ b/packages/vendor-connectors/README.md
@@ -96,3 +96,4 @@ This package is part of the jbcom Python library ecosystem:
 - [extended-data-types](https://pypi.org/project/extended-data-types/) - Foundation utilities
 - [lifecyclelogging](https://pypi.org/project/lifecyclelogging/) - Structured logging
 - [directed-inputs-class](https://pypi.org/project/directed-inputs-class/) - Input handling
+


### PR DESCRIPTION
## Summary

Trigger the initial `202511.3.x` release of vendor-connectors to PyPI.

## Background

- PR #213 migrated to SemVer and set version to `202511.3.0`
- The release CI failed due to externally managed Python (fixed in PR #216)
- The version `202511.3.0` is in the code but never published to PyPI

## Impact

This unblocks:
- `terraform-modules` PR #203 (requires `vendor-connectors>=202511.3`)
- `terraform-modules` PR #209 (depends on #203)

## Test Plan

- [ ] CI passes
- [ ] vendor-connectors publishes to PyPI
- [ ] terraform-modules PR #203 can install the dependency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor README formatting tweak in `packages/vendor-connectors/README.md` (adds trailing newline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c14fef662528d82aeee0bc201bf5c76f7758b871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->