### PR TITLE
fix(ci): Fix syntax error in monorepo commit parser

### DIFF
--- a/scripts/psr/monorepo_parser.py
+++ b/scripts/psr/monorepo_parser.py
@@ -253,7 +253,7 @@ class ConventionalCommitMonorepoParser(
             accumulator["breaking_descriptions"].append(match.group(1) or "")
             return accumulator
 
-                    has_number.search,  # type: ignore[arg-type]
+        if match := self.issue_selector.match(text):
             predicate = regexp(r",? and | *[,;/& ] *").sub(
                 ",", match.group("issue_predicate") or ""
             )


### PR DESCRIPTION
## Summary

**CRITICAL BUG FIX** - The monorepo commit parser has a syntax error that prevents semantic-release from parsing any commits.

## Problem

The `commit_body_components_separator` function had malformed code:
```python
# Before (broken):
        if match := breaking_re.match(text):
            accumulator["breaking_descriptions"].append(match.group(1) or "")
            return accumulator

                    has_number.search,  # type: ignore[arg-type]  # <-- orphaned line!
            predicate = regexp(r",? and | *[,;/& ] *").sub(
```

This caused:
```
::ERROR:: unexpected indent (monorepo_parser.py, line 256)
```

## Fix

Added the missing conditional and removed the orphaned line:
```python
# After (fixed):
        if match := breaking_re.match(text):
            accumulator["breaking_descriptions"].append(match.group(1) or "")
            return accumulator

        if match := self.issue_selector.match(text):  # <-- was missing!
            predicate = regexp(r",? and | *[,;/& ] *").sub(
```

## Impact

Without this fix, **no packages can be released** because semantic-release cannot parse commit messages.

## Test Plan

- [x] `semantic-release --noop version --print` now works without error
- [ ] CI passes
- [ ] Releases work after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restore missing issue-selector condition and remove stray line in `commit_body_components_separator`, resolving a syntax error that broke commit parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9977b8bff151a8362130700820cf8f37644d14e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->