### PR TITLE
feat(connectors): Add cloud_params module with API parameter utilities

### DIFF
--- a/packages/vendor-connectors/src/vendor_connectors/cloud_params.py
+++ b/packages/vendor-connectors/src/vendor_connectors/cloud_params.py
@@ -1,12 +1,15 @@
 """Cloud API call parameter utilities.
 
-These utilities help build properly formatted parameter dictionaries for
-various cloud provider APIs (AWS, Google Cloud, etc.).
+This module provides utilities for building properly formatted parameter
+dictionaries for various cloud provider APIs (AWS, Google Cloud, etc.).
 
-The functions handle common patterns like:
+Key features:
 - Pagination limits (MaxResults/maxResults)
 - Key casing transformations (PascalCase for AWS, camelCase for Google)
 - Null/empty value filtering
+- Support for custom key transformations
+
+Exported via vendor_connectors package.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Properly scoped commit to trigger release of cloud_params utilities
- Functions were added in #226 but used wrong commit scope

## Changes
- get_cloud_call_params, get_aws_call_params, get_google_call_params
- Centralized cloud API parameter building utilities

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the `cloud_params.py` module docstring to clarify features and export details without changing code behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bf8779e6630e635421ccf95b6d69c2c07d2561a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->