### PR TITLE
Extend aws secrets manager operations

### DIFF
--- a/packages/vendor-connectors/src/vendor_connectors/aws/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/aws/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import boto3
 from boto3.resources.base import ServiceResource
@@ -258,6 +258,154 @@ class AWSConnector(DirectedInputsClass):
             f"returned {len(secrets)} secrets, skipped {empty_secret_count} empty"
         )
         return secrets
+
+    def create_secret(
+        self,
+        name: str,
+        secret_value: str,
+        description: str = "",
+        tags: Optional[dict[str, str]] = None,
+        execution_role_arn: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Create a new secret in AWS Secrets Manager."""
+        if not name:
+            raise ValueError("name is required to create a secret")
+        if is_nothing(secret_value):
+            raise ValueError("secret_value is required to create a secret")
+
+        self.logger.info(f"Creating AWS secret: {name}")
+        role_arn = execution_role_arn or self.execution_role_arn
+        secretsmanager = self.get_aws_client(
+            client_name="secretsmanager",
+            execution_role_arn=role_arn,
+        )
+
+        create_kwargs: dict[str, Any] = {"Name": name, "SecretString": secret_value}
+        if description:
+            create_kwargs["Description"] = description
+        if tags:
+            create_kwargs["Tags"] = [{"Key": key, "Value": value} for key, value in tags.items()]
+
+        try:
+            response = secretsmanager.create_secret(**create_kwargs)
+            self.logger.info(f"Created AWS secret ARN: {response.get('ARN')}")
+            return response
+        except ClientError as exc:
+            self.logger.error(f"Failed to create secret {name}", exc_info=True)
+            raise RuntimeError(f"Failed to create secret '{name}'") from exc
+
+    def update_secret(
+        self,
+        secret_id: str,
+        secret_value: str,
+        execution_role_arn: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Update an existing secret value."""
+        if not secret_id:
+            raise ValueError("secret_id is required to update a secret")
+        if is_nothing(secret_value):
+            raise ValueError("secret_value is required to update a secret")
+
+        self.logger.info(f"Updating AWS secret: {secret_id}")
+
+        role_arn = execution_role_arn or self.execution_role_arn
+        secretsmanager = self.get_aws_client(
+            client_name="secretsmanager",
+            execution_role_arn=role_arn,
+        )
+
+        try:
+            response = secretsmanager.update_secret(SecretId=secret_id, SecretString=secret_value)
+            self.logger.info(f"Updated AWS secret ARN: {response.get('ARN', secret_id)}")
+            return response
+        except ClientError as exc:
+            self.logger.error(f"Failed to update secret {secret_id}", exc_info=True)
+            raise RuntimeError(f"Failed to update secret '{secret_id}'") from exc
+
+    def delete_secret(
+        self,
+        secret_id: str,
+        force_delete: bool = False,
+        recovery_window_days: int = 30,
+        execution_role_arn: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Delete a secret from AWS Secrets Manager."""
+        if not secret_id:
+            raise ValueError("secret_id is required to delete a secret")
+
+        if not force_delete and not 7 <= recovery_window_days <= 30:
+            raise ValueError("recovery_window_days must be between 7 and 30 when not forcing deletion")
+
+        self.logger.info(f"Deleting AWS secret: {secret_id}")
+
+        role_arn = execution_role_arn or self.execution_role_arn
+        secretsmanager = self.get_aws_client(
+            client_name="secretsmanager",
+            execution_role_arn=role_arn,
+        )
+
+        delete_kwargs: dict[str, Any] = {"SecretId": secret_id}
+        if force_delete:
+            delete_kwargs["ForceDeleteWithoutRecovery"] = True
+        else:
+            delete_kwargs["RecoveryWindowInDays"] = recovery_window_days
+
+        try:
+            response = secretsmanager.delete_secret(**delete_kwargs)
+            self.logger.info(f"Delete secret request submitted for: {response.get('ARN', secret_id)}")
+            return response
+        except ClientError as exc:
+            self.logger.error(f"Failed to delete secret {secret_id}", exc_info=True)
+            raise RuntimeError(f"Failed to delete secret '{secret_id}'") from exc
+
+    def delete_secrets_matching(
+        self,
+        name_prefix: str,
+        force_delete: bool = False,
+        dry_run: bool = True,
+        execution_role_arn: Optional[str] = None,
+    ) -> list[str]:
+        """Delete all secrets that match the provided name prefix."""
+        if not name_prefix:
+            raise ValueError("name_prefix is required to delete matching secrets")
+
+        self.logger.info(f"Deleting secrets matching prefix: {name_prefix} (dry_run={dry_run})")
+
+        role_arn = execution_role_arn or self.execution_role_arn
+        secrets = self.list_secrets(
+            name_prefix=name_prefix,
+            execution_role_arn=role_arn,
+        )
+
+        secret_arns: list[str] = []
+        for secret_name, value in secrets.items():
+            if isinstance(value, str):
+                secret_arns.append(value)
+            elif isinstance(value, dict) and "ARN" in value:
+                secret_arns.append(value["ARN"])
+            else:
+                self.logger.debug(f"Skipping secret {secret_name} due to missing ARN data")
+
+        if not secret_arns:
+            self.logger.info(f"No secrets found for prefix: {name_prefix}")
+            return []
+
+        if dry_run:
+            self.logger.info(f"Dry run enabled; would delete {len(secret_arns)} secrets for prefix {name_prefix}")
+            return secret_arns
+
+        deleted_arns: list[str] = []
+        for secret_arn in secret_arns:
+            response = self.delete_secret(
+                secret_id=secret_arn,
+                force_delete=force_delete,
+                recovery_window_days=30,
+                execution_role_arn=role_arn,
+            )
+            deleted_arns.append(response.get("ARN", secret_arn))
+
+        self.logger.info(f"Deleted {len(deleted_arns)} secrets for prefix {name_prefix}")
+        return deleted_arns
 
     def copy_secrets_to_s3(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -733,7 +733,7 @@ wheels = [
 
 [[package]]
 name = "directed-inputs-class"
-version = "202511.3.0"
+version = "202511.4.0"
 source = { editable = "packages/directed-inputs-class" }
 dependencies = [
     { name = "case-insensitive-dictionary" },
@@ -3455,7 +3455,7 @@ wheels = [
 
 [[package]]
 name = "vendor-connectors"
-version = "202511.6.1"
+version = "202511.8.0"
 source = { editable = "packages/vendor-connectors" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# MIGRATION: Extend AWS Secrets Manager operations in AWSConnector

## Description

This PR implements full CRUD (Create, Read, Update, Delete) functionality for AWS Secrets Manager within the `AWSConnector`. It introduces `create_secret`, `update_secret`, `delete_secret`, and `delete_secrets_matching` methods. These additions provide comprehensive programmatic control over AWS Secrets Manager resources, supporting features like input validation, optional tagging, recovery window enforcement, and a dry-run mode for bulk deletions. This work addresses the migration efforts outlined in issue #235. The `.cursor/agents/terraform-modules-migration/AGENT_AWS_SECRETS.md` file was not available, so issue #235 served as the authoritative specification.

`uv.lock` was updated to reflect new package versions.

Fixes #235

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Comprehensive unit tests have been added for all new methods in `test_aws_connector.py`. These tests verify:
- Correct payload construction for AWS API calls.
- Input validation and error handling.
- Behavior of optional parameters like `tags`, `description`, `force_delete`, `recovery_window_days`, and `dry_run`.
- Proper interaction with mocked `boto3` clients to ensure functionality without actual AWS calls.

**Test Configuration**:

- Firmware version: N/A
- Hardware: N/A
- Toolchain: N/A
- SDK: N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-9393bfef-686c-4274-a5c1-731a854e0d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9393bfef-686c-4274-a5c1-731a854e0d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Secrets Manager CRUD in `AWSConnector` with validation, tagging/description, recovery window and bulk delete (dry-run), plus unit tests.
> 
> - **AWSConnector (Secrets Manager)**:
>   - Add CRUD methods: `create_secret`, `update_secret`, `delete_secret` (force delete or recovery window), and `delete_secrets_matching` (dry-run support).
>   - Support input validation, optional `tags`/`description` on create, and structured logging.
> - **Tests**:
>   - Add unit tests for new methods, parameter validation, and `list_secrets` path traversal/empty-secret handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5494df4010cf59e39d5199dd2e17aa3ee1d9b50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->