### PR TITLE
Migrate and refactor slack connector

### DIFF
--- a/packages/vendor-connectors/tests/test_slack_connector.py
+++ b/packages/vendor-connectors/tests/test_slack_connector.py
@@ -52,3 +52,120 @@ class TestSlackConnector:
 
         assert ts == "1234567890.123456"
         mock_bot_client.chat_postMessage.assert_called_once()
+
+    @patch("vendor_connectors.slack.SlackConnector._call_api")
+    @patch("vendor_connectors.slack.WebClient")
+    def test_list_users_filters_deleted(
+        self,
+        mock_webclient_class,
+        mock_call_api,
+        base_connector_kwargs,
+    ):
+        """Ensure list_users filters deleted and bot accounts."""
+        mock_call_api.return_value = {
+            "U1": {"id": "U1", "deleted": False, "is_bot": False, "is_app_user": False},
+            "U2": {"id": "U2", "deleted": True, "is_bot": False, "is_app_user": False},
+            "U3": {"id": "U3", "deleted": False, "is_bot": True, "is_app_user": False},
+        }
+
+        mock_user_client = MagicMock()
+        mock_bot_client = MagicMock()
+        mock_webclient_class.side_effect = [mock_user_client, mock_bot_client]
+
+        connector = SlackConnector(token="test-token", bot_token="bot-token", **base_connector_kwargs)
+
+        users = connector.list_users(
+            include_locale=True,
+            limit=200,
+            team_id="T123",
+            include_deleted=False,
+            include_bots=False,
+            include_app_users=False,
+        )
+
+        assert list(users.keys()) == ["U1"]
+        mock_call_api.assert_called_once_with(
+            "users_list",
+            group_by="members",
+            include_locale=True,
+            limit=200,
+            team_id="T123",
+        )
+
+    @patch("vendor_connectors.slack.SlackConnector._call_api")
+    @patch("vendor_connectors.slack.WebClient")
+    def test_list_usergroups_filters_ids(
+        self,
+        mock_webclient_class,
+        mock_call_api,
+        base_connector_kwargs,
+    ):
+        """Ensure list_usergroups filters to the requested IDs."""
+        mock_call_api.return_value = {
+            "S1": {"id": "S1", "name": "Ops"},
+            "S2": {"id": "S2", "name": "Eng"},
+        }
+
+        mock_user_client = MagicMock()
+        mock_bot_client = MagicMock()
+        mock_webclient_class.side_effect = [mock_user_client, mock_bot_client]
+
+        connector = SlackConnector(token="test-token", bot_token="bot-token", **base_connector_kwargs)
+
+        groups = connector.list_usergroups(
+            include_disabled=True,
+            include_count=True,
+            include_users=True,
+            team_id="T123",
+            usergroup_ids="S1,S3",
+        )
+
+        assert groups == {"S1": {"id": "S1", "name": "Ops"}}
+        mock_call_api.assert_called_once_with(
+            "usergroups_list",
+            group_by="usergroups",
+            include_disabled=True,
+            include_count=True,
+            include_users=True,
+            team_id="T123",
+        )
+
+    @patch("vendor_connectors.slack.SlackConnector._call_api")
+    @patch("vendor_connectors.slack.WebClient")
+    def test_list_conversations_channels_only(
+        self,
+        mock_webclient_class,
+        mock_call_api,
+        base_connector_kwargs,
+    ):
+        """Ensure list_conversations can filter to Slack channels."""
+        mock_call_api.return_value = {
+            "C1": {"id": "C1", "is_channel": True},
+            "G1": {"id": "G1", "is_channel": False},
+        }
+
+        mock_user_client = MagicMock()
+        mock_bot_client = MagicMock()
+        mock_webclient_class.side_effect = [mock_user_client, mock_bot_client]
+
+        connector = SlackConnector(token="test-token", bot_token="bot-token", **base_connector_kwargs)
+
+        conversations = connector.list_conversations(
+            exclude_archived=True,
+            limit=50,
+            team_id="T123",
+            types=["public_channel", "private_channel"],
+            channels_only=True,
+            cursor="cursor123",
+        )
+
+        assert conversations == {"C1": {"id": "C1", "is_channel": True}}
+        mock_call_api.assert_called_once_with(
+            "conversations_list",
+            group_by="channels",
+            exclude_archived=True,
+            limit=50,
+            team_id="T123",
+            types="private_channel,public_channel",
+            cursor="cursor123",
+        )


### PR DESCRIPTION
# MIGRATION: Extend Slack Connector with Directory Operations and Google Docstrings

## Description

This PR extends the `SlackConnector` to align with the `terraform-modules` migration requirements. It introduces new capabilities for listing Slack users, user groups, and conversations, and updates existing methods to use Google-style docstrings.

The changes include:
*   **Added `list_usergroups` method**: Provides functionality to list Slack user groups with optional filtering by ID, mirroring `terraform-modules` usage.
*   **Enhanced `list_users` and `list_conversations`**: Updated to support more robust filtering options, including an identifier normalizer and CSV-safe conversation type handling.
*   **Standardized Docstrings**: All new and modified methods now use Google-style docstrings for improved clarity and consistency.

This work addresses the migration of Slack connector functionality as outlined in the task.

Fixes #232

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this been tested?

Focused unit tests were added to `packages/vendor-connectors/tests/test_slack_connector.py` to verify the filtering logic for `list_users`, `list_usergroups`, and `list_conversations` by mocking the `_call_api` method.

- [x] `uv run pytest packages/vendor-connectors/tests/test_slack_connector.py --cov-fail-under=0`

**Test Configuration**:
N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Notes / Follow-ups

The referenced `.cursor/agents/terraform-modules-migration/AGENT_SLACK_OPERATIONS.md` and GitHub issue `#232` were not accessible during development. Implementation decisions were based on the existing connector and tests. If additional requirements live in those locations, please share them so we can reconcile any gaps.

---
<a href="https://cursor.com/background-agent?bcId=bc-911ea566-1b4b-4205-94ba-e4cb244e4b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-911ea566-1b4b-4205-94ba-e4cb244e4b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends Slack connector with `list_usergroups`, richer filtering for `list_users`/`list_conversations` (including type normalization), typed helper blocks, and targeted tests.
> 
> - **Slack Connector**:
>   - **New**: `list_usergroups(...)` with optional flags and ID filtering via `_normalize_identifier_filter`.
>   - **Enhanced**:
>     - `list_users(...)`: adds filtering for deleted/bot/app users; returns ID-keyed mapping.
>     - `list_conversations(...)`: supports CSV-normalized `types` and `channels_only` filtering.
>     - `get_bot_channels()`: typed return and error handling via `SlackAPIError`.
>     - Helper blocks (`get_divider`, `get_header_block`, `get_field_context_message_blocks`, `get_key_value_blocks`, `get_rich_text_blocks`): add type hints and clearer behavior.
>     - `_call_api(...)`: clarified grouping/retry semantics in docstring.
> - **Tests**:
>   - Add unit tests covering user filtering, usergroup ID filtering, and conversations `channels_only`; verify `send_message` and channel resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 469324587620fe00827851c74319c290078d580a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->