### PR TITLE
Verify aws operations against terraform modules

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -733,7 +733,7 @@ wheels = [
 
 [[package]]
 name = "directed-inputs-class"
-version = "202511.3.0"
+version = "202511.4.0"
 source = { editable = "packages/directed-inputs-class" }
 dependencies = [
     { name = "case-insensitive-dictionary" },
@@ -3455,7 +3455,7 @@ wheels = [
 
 [[package]]
 name = "vendor-connectors"
-version = "202511.6.1"
+version = "202511.8.0"
 source = { editable = "packages/vendor-connectors" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# AWS Connector QC Verification Findings and Dependency Updates

## Description

This pull request documents the findings from the QC verification of AWS operations in `vendor-connectors` against `terraform-modules`, as detailed in GitHub issue #230.

The verification identified several AWS functionalities present in `terraform-modules` that are not yet ported to `vendor-connectors`, including:
- AWS Organizations operations (e.g., `get_aws_organization_accounts`, `get_aws_controltower_accounts`, `get_aws_accounts`).
- AWS SSO operations (e.g., `get_identity_store_id`, `get_aws_users`, `get_aws_groups`, `get_aws_sso_permission_sets`, `get_aws_sso_account_assignments`).
- S3 helper functions (`get_s3_buckets_containing_name`, `get_s3_bucket_features`).
- Base connector functionality like `get_caller_account_id`.

These discrepancies have been documented on the tracker for #230.

This PR also includes minor dependency version updates in `uv.lock` for `directed-inputs-class` and `vendor-connectors`, which occurred during the verification environment setup.

Fixes #230

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Chore (dependency updates, build process changes, etc.)

## How has this been tested?

`uv run python -m pytest packages/vendor-connectors/tests/test_aws_connector.py -v` was executed. Individual tests within the module passed, but the overall repository-level coverage threshold (`fail_under=80`) prevented a full pass due to untouched modules.

**Test Configuration**:

- Firmware version: N/A
- Hardware: N/A
- Toolchain: uv
- SDK: N/A

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (Findings documented in #230)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (Individual tests pass, overall coverage threshold prevents full pass)
- [ ] Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-09948622-174f-4d77-b79c-afe3cb99db40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09948622-174f-4d77-b79c-afe3cb99db40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump `vendor-connectors` to 202511.8.0 and `directed-inputs-class` to 202511.4.0 in `uv.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53b7d0a25a63bcbb26c4b5d65729f0b61b91134d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->