### PR TITLE
Remediate google workspace operation discrepancies

### DIFF
--- a/packages/vendor-connectors/tests/test_google_connector.py
+++ b/packages/vendor-connectors/tests/test_google_connector.py
@@ -5,21 +5,68 @@ from unittest.mock import MagicMock, patch
 from vendor_connectors.google import GoogleConnector
 
 
+def _service_account():
+    """Return a reusable service account payload."""
+    return {
+        "type": "service_account",
+        "client_email": "test@example.iam.gserviceaccount.com",
+        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...test\n-----END RSA PRIVATE KEY-----\n",
+        "private_key_id": "key123",
+        "project_id": "test-project",
+        "client_id": "123456789",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+
+
+class _StubRequest:
+    """Simple request stub for the Google Admin SDK."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def execute(self):
+        return self._payload
+
+
+class _StubCollection:
+    """Collection stub that yields predefined response pages."""
+
+    def __init__(self, pages):
+        self._pages = pages
+        self._index = 0
+
+    def list(self, **_):
+        payload = self._pages[self._index]
+        self._index += 1
+        return _StubRequest(payload)
+
+
+class _StubAdminDirectoryService:
+    """Admin Directory service stub exposing users() and groups()."""
+
+    def __init__(self, *, user_pages=None, group_pages=None):
+        if user_pages is None:
+            user_pages = [{"users": []}]
+        if group_pages is None:
+            group_pages = [{"groups": []}]
+
+        self._user_collection = _StubCollection(user_pages)
+        self._group_collection = _StubCollection(group_pages)
+
+    def users(self):
+        return self._user_collection
+
+    def groups(self):
+        return self._group_collection
+
+
 class TestGoogleConnector:
     """Test suite for GoogleConnector."""
 
     def test_init_with_dict_service_account(self, base_connector_kwargs):
         """Test initialization with dictionary service account."""
-        service_account = {
-            "type": "service_account",
-            "client_email": "test@example.iam.gserviceaccount.com",
-            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...test\n-----END RSA PRIVATE KEY-----\n",
-            "private_key_id": "key123",
-            "project_id": "test-project",
-            "client_id": "123456789",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-        }
+        service_account = _service_account()
 
         connector = GoogleConnector(
             service_account_info=service_account,
@@ -32,16 +79,7 @@ class TestGoogleConnector:
     @patch("vendor_connectors.google.service_account.Credentials.from_service_account_info")
     def test_credentials_property(self, mock_from_sa, base_connector_kwargs):
         """Test credentials property creates credentials."""
-        service_account = {
-            "type": "service_account",
-            "client_email": "test@example.iam.gserviceaccount.com",
-            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...test\n-----END RSA PRIVATE KEY-----\n",
-            "private_key_id": "key123",
-            "project_id": "test-project",
-            "client_id": "123456789",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-        }
+        service_account = _service_account()
 
         mock_credentials = MagicMock()
         mock_from_sa.return_value = mock_credentials
@@ -59,16 +97,7 @@ class TestGoogleConnector:
     @patch("vendor_connectors.google.build")
     def test_get_service(self, mock_build, mock_from_sa, base_connector_kwargs):
         """Test getting a Google service."""
-        service_account = {
-            "type": "service_account",
-            "client_email": "test@example.iam.gserviceaccount.com",
-            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...test\n-----END RSA PRIVATE KEY-----\n",
-            "private_key_id": "key123",
-            "project_id": "test-project",
-            "client_id": "123456789",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-        }
+        service_account = _service_account()
 
         mock_credentials = MagicMock()
         mock_from_sa.return_value = mock_credentials
@@ -88,16 +117,7 @@ class TestGoogleConnector:
     @patch("vendor_connectors.google.build")
     def test_get_service_caching(self, mock_build, mock_from_sa, base_connector_kwargs):
         """Test that services are cached."""
-        service_account = {
-            "type": "service_account",
-            "client_email": "test@example.iam.gserviceaccount.com",
-            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...test\n-----END RSA PRIVATE KEY-----\n",
-            "private_key_id": "key123",
-            "project_id": "test-project",
-            "client_id": "123456789",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-        }
+        service_account = _service_account()
 
         mock_credentials = MagicMock()
         mock_from_sa.return_value = mock_credentials
@@ -116,3 +136,87 @@ class TestGoogleConnector:
         # Build should only be called once
         assert mock_build.call_count == 1
         assert service1 is service2
+
+    @patch.object(GoogleConnector, "get_admin_directory_service")
+    def test_list_users_filters_and_transforms(self, mock_get_service, base_connector_kwargs):
+        """Ensure list_users applies filtering, flattening, and keying."""
+        user_pages = [
+            {
+                "users": [
+                    {
+                        "primaryEmail": "bot@example.com",
+                        "orgUnitPath": "/Bots",
+                        "isBot": True,
+                        "name": {"fullName": "Bot Account", "givenName": "Bot", "familyName": "Account"},
+                    },
+                    {
+                        "primaryEmail": "engineer@example.com",
+                        "orgUnitPath": "/Engineering",
+                        "name": {"fullName": "Eng One", "givenName": "Eng", "familyName": "One"},
+                    },
+                ],
+                "nextPageToken": "token-1",
+            },
+            {
+                "users": [
+                    {
+                        "primaryEmail": "suspended@example.com",
+                        "orgUnitPath": "/Engineering",
+                        "suspended": True,
+                        "name": {"fullName": "Susp User", "givenName": "Susp", "familyName": "User"},
+                    },
+                    {
+                        "primaryEmail": "sales@example.com",
+                        "orgUnitPath": "/Sales",
+                        "name": {"fullName": "Sales User", "givenName": "Sales", "familyName": "User"},
+                    },
+                ],
+            },
+        ]
+        mock_get_service.return_value = _StubAdminDirectoryService(user_pages=user_pages)
+
+        connector = GoogleConnector(service_account_info=_service_account(), **base_connector_kwargs)
+        result = connector.list_users(
+            ou_allow_list=["/Engineering"],
+            ou_deny_list=["/Sales"],
+            flatten_names=True,
+            key_by_email=True,
+        )
+
+        assert "bot@example.com" not in result
+        assert "suspended@example.com" not in result
+        assert "sales@example.com" not in result
+        assert result["engineer@example.com"]["full_name"] == "Eng One"
+        assert result["engineer@example.com"]["given_name"] == "Eng"
+        assert result["engineer@example.com"]["family_name"] == "One"
+
+    @patch.object(GoogleConnector, "get_admin_directory_service")
+    def test_list_groups_key_by_email_and_filters(self, mock_get_service, base_connector_kwargs):
+        """Ensure list_groups supports filtering and keying similar to list_users."""
+        group_pages = [
+            {
+                "groups": [
+                    {"email": "bots@example.com", "orgUnitPath": "/Bots", "type": "BOT"},
+                    {
+                        "email": "keepers@example.com",
+                        "orgUnitPath": "/Engineering",
+                        "suspended": True,
+                    },
+                    {"primaryEmail": "team@example.com", "orgUnitPath": "/Engineering"},
+                ]
+            }
+        ]
+        mock_get_service.return_value = _StubAdminDirectoryService(group_pages=group_pages)
+
+        connector = GoogleConnector(service_account_info=_service_account(), **base_connector_kwargs)
+        result = connector.list_groups(
+            ou_deny_list=["/Bots"],
+            include_suspended=True,
+            key_by_email=True,
+        )
+
+        assert "bots@example.com" not in result
+        assert "keepers@example.com" in result
+        assert result["keepers@example.com"]["suspended"] is True
+        assert "team@example.com" in result
+        assert result["team@example.com"]["primaryEmail"] == "team@example.com"


### PR DESCRIPTION
# feat: Enhance Google Connector with Advanced Filtering and Data Transformation

## Description

This PR addresses QC findings by enhancing the `GoogleConnector`'s `list_users()` and `list_groups()` methods. It introduces new optional keyword-only parameters for advanced filtering and data transformation, while maintaining backward compatibility.

Specifically, the following capabilities have been added:
-   **OU filtering**: `ou_allow_list` and `ou_deny_list` parameters to filter users/groups by Organizational Unit path.
-   **Account status gating**: `include_suspended` (default `False`) to control inclusion of suspended accounts.
-   **Bot exclusion**: `exclude_bots` (default `True`) to filter out bot/service accounts.
-   **Name flattening**: `flatten_names` (default `False`) to flatten the nested name structure of user objects.
-   **Keying by email**: `key_by_email` (default `False`) to return results as a dictionary keyed by email address instead of a list.

Additionally, the `GoogleConnector`'s default scopes have been updated to include necessary read-only permissions for Admin Directory users, groups, and organizational units.

Fixes # (issue)

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How has this been tested?

New unit tests have been added to `tests/test_google_connector.py` to verify the functionality of the new filtering and transformation options for both `list_users` and `list_groups`. These tests utilize mocked Admin Directory services to ensure deterministic results.

-   [x] `test_list_users_filters_and_transforms`: Asserts correct behavior for OU filtering, bot exclusion, suspended account exclusion, name flattening, and key-by-email for users.
-   [x] `test_list_groups_key_by_email_and_filters`: Asserts correct behavior for OU filtering, suspended account inclusion, and key-by-email for groups.

**Test Configuration**:

-   `uv run python -m pytest packages/vendor-connectors/tests/test_google_connector.py -o addopts="--cov=vendor_connectors.google --cov-report=term-missing"`

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation (method signatures updated)
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules

---
<a href="https://cursor.com/background-agent?bcId=bc-cce7e705-e41a-4a68-9da5-99e1c56f6af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cce7e705-e41a-4a68-9da5-99e1c56f6af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `GoogleConnector` with OU-based filtering, suspended/bot gating, optional name flattening, and key-by-email results, plus adds read-only Admin Directory scopes and tests.
> 
> - **Google Connector (`vendor_connectors/google/__init__.py`)**:
>   - **Default scopes**: Add read-only Admin Directory scopes (`user.readonly`, `group.readonly`, `orgunit.readonly`).
>   - **Filtering/transform helpers**: New internal utilities for resolving options, normalizing sequences/OU paths, detecting bots, flattening names, and keying entries by email.
>   - **`list_users` / `list_groups`**:
>     - Add keyword-only params: `ou_allow_list`, `ou_deny_list`, `include_suspended`, `exclude_bots`, `flatten_names`, `key_by_email`.
>     - Apply OU allow/deny filtering, suspended/bot gating, optional name flattening.
>     - Support returning results keyed by email; improved retrieval/filtered count logging.
> - **Tests (`tests/test_google_connector.py`)**:
>   - Add stubs for Admin Directory paging and shared service account fixture.
>   - New tests validating filtering, name flattening, and key-by-email for users and groups; update existing service/credential tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f18eec7ebd44b4c36452d49f1ed5143165897ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->