### PR TITLE
feat(connectors): Add terraform-aligned Google constants and idempotent methods

### DIFF
--- a/packages/vendor-connectors/src/vendor_connectors/google/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/google/__init__.py
@@ -121,6 +121,33 @@ class GoogleConnector(DirectedInputsClass):
             scopes=self.scopes,
         ).with_subject(subject)
 
+    def get_connector_for_user(
+        self,
+        primary_email: str,
+        scopes: Optional[list[str]] = None,
+    ) -> GoogleConnector:
+        """Get a connector instance impersonating a specific user.
+
+        This is useful for terraform-style operations where you need to perform
+        actions as a specific user rather than the service account.
+
+        Args:
+            primary_email: Email address of the user to impersonate.
+            scopes: Optional custom scopes. Defaults to current connector's scopes.
+
+        Returns:
+            A new GoogleConnector instance configured to impersonate the user.
+        """
+        return GoogleConnector(
+            service_account_info=self.service_account_info,
+            scopes=scopes or self.scopes,
+            subject=primary_email,
+            logger=self.logging,
+            inputs=self.inputs,
+            from_environment=False,
+            from_stdin=False,
+        )
+
     # =========================================================================
     # Service Client Creation
     # =========================================================================
@@ -508,6 +535,15 @@ class GoogleConnector(DirectedInputsClass):
 # Import submodule operations
 from vendor_connectors.google.billing import GoogleBillingMixin
 from vendor_connectors.google.cloud import GoogleCloudMixin
+from vendor_connectors.google.constants import (
+    DEFAULT_DOMAIN,
+    DEFAULT_USER_OUS,
+    GCP_KMS,
+    GCP_REQUIRED_APIS,
+    GCP_REQUIRED_ORGANIZATION_ROLES,
+    GCP_REQUIRED_ROLES,
+    GCP_SECURITY_PROJECT,
+)
 from vendor_connectors.google.services import GoogleServicesMixin
 from vendor_connectors.google.workspace import GoogleWorkspaceMixin
 
@@ -526,11 +562,21 @@ class GoogleConnectorFull(
 
 
 __all__ = [
+    # Core connector classes
     "GoogleConnector",
     "GoogleConnectorFull",
+    # Mixins
     "GoogleWorkspaceMixin",
     "GoogleCloudMixin",
     "GoogleBillingMixin",
     "GoogleServicesMixin",
+    # Constants
     "DEFAULT_SCOPES",
+    "DEFAULT_DOMAIN",
+    "DEFAULT_USER_OUS",
+    "GCP_SECURITY_PROJECT",
+    "GCP_KMS",
+    "GCP_REQUIRED_APIS",
+    "GCP_REQUIRED_ORGANIZATION_ROLES",
+    "GCP_REQUIRED_ROLES",
 ]

--- a/packages/vendor-connectors/src/vendor_connectors/google/constants.py
+++ b/packages/vendor-connectors/src/vendor_connectors/google/constants.py
@@ -1,0 +1,106 @@
+"""Google connector constants aligned with terraform-modules settings.
+
+These constants provide default configurations for Google Cloud and Workspace
+operations that match the terraform-modules library's established patterns.
+"""
+
+from __future__ import annotations
+
+DEFAULT_DOMAIN = "flipsidecrypto.com"
+
+# Full OAuth scopes matching terraform-modules for maximum compatibility
+DEFAULT_SCOPES = [
+    "https://mail.google.com/",
+    "https://www.googleapis.com/auth/apps.alerts",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/cloud-identity",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.activity",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
+    "https://www.googleapis.com/auth/gmail.settings.sharing",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/admin.directory.user",
+    "https://www.googleapis.com/auth/admin.directory.user.readonly",
+    "https://www.googleapis.com/auth/admin.directory.userschema",
+    "https://www.googleapis.com/auth/admin.directory.group",
+    "https://www.googleapis.com/auth/admin.directory.orgunit",
+    "https://www.googleapis.com/auth/apps.groups.settings",
+    "https://www.googleapis.com/auth/apps.licensing",
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/cloud-billing",
+    "https://www.googleapis.com/auth/bigquery",
+    "https://www.googleapis.com/auth/iam",
+    "https://www.googleapis.com/auth/compute",
+    "https://www.googleapis.com/auth/cloudkms",
+    "https://www.googleapis.com/auth/logging.admin",
+    "https://www.googleapis.com/auth/monitoring",
+    "https://www.googleapis.com/auth/sqlservice.admin",
+    "https://www.googleapis.com/auth/devstorage.full_control",
+    "https://www.googleapis.com/auth/pubsub",
+    "https://www.googleapis.com/auth/service.management",
+]
+
+# GCP Security Project defaults
+GCP_SECURITY_PROJECT = {
+    "id": "flipside-security-admin",
+    "name": "Security Administration",
+    "resource_labels": {
+        "managed-by": "terraform",
+        "environment": "global",
+        "team": "security",
+    },
+}
+
+# KMS configuration for terraform secrets
+GCP_KMS = {
+    "keyring_name": "terraform-secrets",
+    "key_name": "terraform-key",
+    "key_rotation_period": "7776000s",  # 90 days
+}
+
+# Required IAM roles for organization-level operations
+GCP_REQUIRED_ORGANIZATION_ROLES = [
+    "roles/owner",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/serviceusage.serviceUsageAdmin",
+]
+
+# Required IAM roles for project-level operations
+GCP_REQUIRED_ROLES = GCP_REQUIRED_ORGANIZATION_ROLES + [
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/storage.admin",
+]
+
+# Required APIs for standard GCP operations
+GCP_REQUIRED_APIS = [
+    "bigquery.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "cloudidentity.googleapis.com",
+    "cloudassets.googleapis.com",
+    "cloudkms.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "iam.googleapis.com",
+    "orgpolicy.googleapis.com",
+    "pubsub.googleapis.com",
+    "serviceusage.googleapis.com",
+    "sqladmin.googleapis.com",
+    "storage.googleapis.com",
+]
+
+# Default OUs for user filtering
+DEFAULT_USER_OUS = ["/Users", "Users/2FANotEnforced", "/Contract"]
+
+__all__ = [
+    "DEFAULT_DOMAIN",
+    "DEFAULT_SCOPES",
+    "GCP_SECURITY_PROJECT",
+    "GCP_KMS",
+    "GCP_REQUIRED_APIS",
+    "GCP_REQUIRED_ORGANIZATION_ROLES",
+    "GCP_REQUIRED_ROLES",
+    "DEFAULT_USER_OUS",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,15 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-# UV Workspace - manages all packages in packages/
+# UV Workspace - manages Python packages in packages/
+# Note: cursor-fleet is a TypeScript package (has package.json, not pyproject.toml)
 [tool.uv.workspace]
-members = ["packages/*"]
+members = [
+    "packages/extended-data-types",
+    "packages/lifecyclelogging",
+    "packages/directed-inputs-class",
+    "packages/vendor-connectors",
+]
 
 [tool.uv.sources]
 extended-data-types = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -733,7 +733,7 @@ wheels = [
 
 [[package]]
 name = "directed-inputs-class"
-version = "202511.4.0"
+version = "202511.5.0"
 source = { editable = "packages/directed-inputs-class" }
 dependencies = [
     { name = "case-insensitive-dictionary" },


### PR DESCRIPTION
## Summary

This PR properly integrates the unique contributions from PR #243 (agent bc-f5391b3e-5208-4c16-94f8-ee24601f04be) into the established modular architecture.

### Background
- PR #241 merged the core filtering functionality (ou_allow_list, ou_deny_list, exclude_bots, flatten_names, key_by_email)
- PR #243 had these same features PLUS unique additions, but used a monolithic approach that conflicted with the modular structure
- This PR extracts only the **unique** contributions from #243 and adds them to the modular structure

### What's Added

1. **`google/constants.py`** - Terraform-modules aligned configurations:
   - `DEFAULT_DOMAIN` - Default workspace domain
   - `DEFAULT_SCOPES` - Full OAuth scope list matching terraform-modules
   - `GCP_SECURITY_PROJECT`, `GCP_KMS` - Security configurations
   - `GCP_REQUIRED_APIS`, `GCP_REQUIRED_ROLES` - Setup requirements
   - `DEFAULT_USER_OUS` - User organizational unit defaults

2. **`google/workspace.py`** - Idempotent create methods:
   - `create_or_update_user()` - Create user or update if exists
   - `create_or_update_group()` - Create group or update if exists

3. **`google/__init__.py`** - User impersonation:
   - `get_connector_for_user()` - Get a connector impersonating a specific user

### Supersedes
- **PR #243** should be closed as this PR properly incorporates its unique contributions

## Test plan
- [x] All existing Google connector tests pass
- [x] Imports verified: `from vendor_connectors.google import GoogleConnector, DEFAULT_DOMAIN, GCP_REQUIRED_APIS`
- [x] Linting passes

Fixes #231 (partial - completes terraform-parity additions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces terraform-aligned Google constants, adds idempotent user/group create-or-update methods, and a user-impersonating connector; updates exports and workspace config.
> 
> - **Google Connectors**:
>   - **Constants** (`vendor_connectors/google/constants.py`): Add terraform-aligned defaults (`DEFAULT_DOMAIN`, `DEFAULT_SCOPES`, `GCP_SECURITY_PROJECT`, `GCP_KMS`, `GCP_REQUIRED_APIS`, `GCP_REQUIRED_ORGANIZATION_ROLES`, `GCP_REQUIRED_ROLES`, `DEFAULT_USER_OUS`).
>   - **Workspace Ops** (`vendor_connectors/google/workspace.py`): Add `create_or_update_user()` and `create_or_update_group()` for idempotent management.
>   - **Impersonation** (`vendor_connectors/google/__init__.py`): Add `get_connector_for_user()` to create a connector impersonating a given user.
>   - **Exports**: Import and re-export new constants in `__init__.py`.
> - **Build/Config**:
>   - Update `pyproject.toml` UV workspace members to explicit package list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 379973787d13a17906292639f869c5713690b069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->