### PR TITLE
feat: Add python-terraform-bridge package

### DIFF
--- a/packages/python-terraform-bridge/README.md
+++ b/packages/python-terraform-bridge/README.md
@@ -1,0 +1,280 @@
+# python-terraform-bridge
+
+Bridge Python classes to Terraform external data sources and modules.
+
+## Overview
+
+`python-terraform-bridge` provides a framework for:
+
+1. **Generating Terraform modules** from Python `DirectedInputsClass` methods
+2. **Running as a Terraform external data provider** via stdin/stdout
+3. **Decorator-based registration** as an alternative to docstring parsing
+
+This package extracts and generalizes the Terraform integration layer from specific implementations, making it reusable for any Python codebase.
+
+## Installation
+
+```bash
+pip install python-terraform-bridge
+```
+
+Or with development dependencies:
+
+```bash
+pip install "python-terraform-bridge[dev]"
+```
+
+## Quick Start
+
+### Decorator-Based Registration (Recommended)
+
+```python
+from directed_inputs_class import DirectedInputsClass
+from python_terraform_bridge import TerraformRegistry, data_source
+
+registry = TerraformRegistry()
+
+class MyConnector(DirectedInputsClass):
+    @registry.data_source(key="users", module_class="myservice")
+    def list_users(self, domain: str = None) -> dict:
+        """List all users in the organization."""
+        return {"user1": {"name": "Alice"}, "user2": {"name": "Bob"}}
+
+    @registry.data_source(key="groups", module_class="myservice")
+    def list_groups(self, type_filter: str = "all") -> dict:
+        """List all groups."""
+        return {"admins": {...}, "users": {...}}
+
+# Generate Terraform modules
+registry.generate_modules("./terraform-modules")
+```
+
+This generates:
+```
+terraform-modules/
+├── myservice/
+│   ├── myservice-list-users/
+│   │   └── main.tf.json
+│   └── myservice-list-groups/
+│       └── main.tf.json
+```
+
+### Docstring-Based Configuration (Legacy/Compatible)
+
+```python
+class MyDataSource(DirectedInputsClass):
+    def list_users(self, domain: str = None) -> dict:
+        """List all users.
+
+        generator=key: users, type: data_source, module_class: myservice
+
+        name: domain, required: false, type: string, description: "Domain filter"
+        """
+        return {"user1": {...}}
+```
+
+### Running as External Data Provider
+
+```bash
+# Generate modules
+terraform-bridge generate mypackage:MyDataSource -o ./terraform-modules
+
+# Run directly (Terraform calls this)
+echo '{"domain": "example.com"}' | python -m python_terraform_bridge run mypackage:MyDataSource list_users
+```
+
+### Using Generated Modules in Terraform
+
+```hcl
+module "users" {
+  source = "./terraform-modules/myservice/myservice-list-users"
+
+  domain = "example.com"
+}
+
+output "user_list" {
+  value = module.users.users
+}
+```
+
+## CLI Reference
+
+```bash
+# Generate Terraform modules
+terraform-bridge generate <module:Class> [options]
+  -o, --output        Output directory (default: terraform-modules)
+  -c, --module-class  Module class prefix
+  -b, --binary        Runtime invocation command
+
+# List available methods
+terraform-bridge list <module:Class> [--json]
+
+# Run as external data provider
+terraform-bridge run <module:Class> <method_name>
+```
+
+## API Reference
+
+### TerraformRegistry
+
+```python
+registry = TerraformRegistry(name="myregistry")
+
+# Register as data source
+@registry.data_source(
+    key="output_key",           # Output key name
+    module_class="namespace",   # Module prefix
+    description="...",          # Override docstring
+    parameters=[...],           # Explicit parameters
+    env_variables={...},        # Environment variables to read
+    always_run=False,           # Always trigger execution
+    plaintext_output=False,     # Output plaintext vs base64 JSON
+)
+def my_method(...): ...
+
+# Register as null_resource (for side effects)
+@registry.null_resource(module_class="namespace")
+def my_action(...): ...
+
+# Generate all modules
+registry.generate_modules("./output")
+```
+
+### TerraformModuleResources
+
+Low-level module generation:
+
+```python
+from python_terraform_bridge import TerraformModuleResources
+
+resources = TerraformModuleResources(
+    module_name="list_users",
+    docstring=my_method.__doc__,
+    terraform_modules_dir="./modules",
+    terraform_modules_class="myservice",
+)
+
+# Get as external_data module
+module_json = resources.get_external_data(key="users")
+
+# Get as null_resource module
+module_json = resources.get_null_resource()
+
+# Get based on docstring configuration
+module_json = resources.get_mixed()
+```
+
+### TerraformRuntime
+
+For programmatic invocation:
+
+```python
+from python_terraform_bridge import TerraformRuntime
+
+runtime = TerraformRuntime(
+    data_source_class=MyDataSource,
+    null_resource_class=MyActions,
+)
+
+# Invoke directly
+result = runtime.invoke("list_users", domain="example.com")
+
+# Run as CLI
+runtime.run()
+```
+
+### Lambda Handler Factory
+
+For AWS Lambda:
+
+```python
+from python_terraform_bridge.runtime import lambda_handler_factory
+
+handler = lambda_handler_factory(MyDataSource)
+
+# Lambda event:
+# {"method": "list_users", "kwargs": {"domain": "example.com"}}
+```
+
+## Docstring Format
+
+Parameters are defined per line:
+
+```python
+"""Short description.
+
+generator=key: output_key, type: data_source, module_class: prefix
+
+name: param_name, type: string, required: true, description: "..."
+name: optional_param, type: string, required: false, default: "value"
+name: sensitive_param, type: string, sensitive: true
+
+env=name: MY_TOKEN, required: true, sensitive: true
+
+extra_output=key: secondary_output
+sub_key=key: nested_value, json_encode: true
+"""
+```
+
+### Generator Parameters
+
+- `key`: Output key name (required)
+- `type`: `data_source` or `null_resource`
+- `module_class`: Module namespace prefix
+- `plaintext_output`: `true` to skip base64 encoding
+- `always`: `true` to always trigger
+
+### Parameter Types
+
+- `string`, `bool`, `number`, `any`
+- `list(any)`, `map(any)`
+- Auto-inferred from Python type hints
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Your Application                           │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌────────────────┐  │
+│  │ DirectedInputs  │  │   vendor-       │  │  Your Custom   │  │
+│  │     Class       │  │   connectors    │  │    Classes     │  │
+│  └────────┬────────┘  └────────┬────────┘  └───────┬────────┘  │
+└───────────┼─────────────────────┼──────────────────┼────────────┘
+            │                     │                  │
+            v                     v                  v
+┌─────────────────────────────────────────────────────────────────┐
+│                   python-terraform-bridge                       │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────┐  │
+│  │  Registry    │  │  Module      │  │  Runtime             │  │
+│  │  (decorators)│  │  Resources   │  │  (stdin/stdout)      │  │
+│  └──────────────┘  └──────────────┘  └──────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+            │                     │                  │
+            v                     v                  v
+┌─────────────────────────────────────────────────────────────────┐
+│                       Terraform                                 │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  module "users" {                                          │ │
+│  │    source = "./terraform-modules/myservice/list-users"     │ │
+│  │    domain = "example.com"                                  │ │
+│  │  }                                                         │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Contributing
+
+This package is part of the jbcom-control-center monorepo.
+
+```bash
+# Run tests
+pytest packages/python-terraform-bridge/tests/
+
+# Lint
+ruff check packages/python-terraform-bridge/
+ruff format packages/python-terraform-bridge/
+```
+
+## License
+
+MIT License - see [LICENSE](../../LICENSE) for details.

--- a/packages/python-terraform-bridge/pyproject.toml
+++ b/packages/python-terraform-bridge/pyproject.toml
@@ -1,0 +1,79 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "python-terraform-bridge"
+version = "202511.1.0"
+description = "Bridge Python classes to Terraform external data sources and modules"
+authors = [
+    { name = "Jon Bogaty", email = "jon@jonbogaty.com" }
+]
+maintainers = [
+    { name = "Jon Bogaty", email = "jon@jonbogaty.com" }
+]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: System :: Systems Administration",
+    "Typing :: Typed",
+]
+keywords = [
+    "terraform",
+    "infrastructure",
+    "iac",
+    "code-generation",
+    "external-data",
+    "bridge",
+]
+dependencies = [
+    "directed-inputs-class>=202511.3.0",
+    "extended-data-types>=202511.9.0",
+    "lifecyclelogging>=202511.3.0",
+    "tssplit>=0.1.1",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+]
+dev = [
+    "python-terraform-bridge[test]",
+    "ruff>=0.8.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/jbcom/jbcom-control-center"
+Repository = "https://github.com/jbcom/jbcom-control-center"
+Documentation = "https://github.com/jbcom/jbcom-control-center/tree/main/packages/python-terraform-bridge"
+
+[project.scripts]
+terraform-bridge = "python_terraform_bridge.cli:main"
+
+[tool.hatch.build.targets.sdist]
+include = ["/src"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/python_terraform_bridge"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+tag_format = "python-terraform-bridge-v{version}"
+commit_message = "chore(ptb-release): release python-terraform-bridge v{version} [skip ci]"

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/__init__.py
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/__init__.py
@@ -1,0 +1,62 @@
+"""Python Terraform Bridge - Bridge Python classes to Terraform external data sources.
+
+This package provides tools to:
+1. Generate Terraform modules from DirectedInputsClass methods
+2. Run as an external data provider for Terraform
+3. Support both docstring-based and decorator-based registration
+
+Example usage with decorators:
+
+    from python_terraform_bridge import TerraformRegistry, data_source
+    from directed_inputs_class import DirectedInputsClass
+
+    registry = TerraformRegistry()
+
+    class MyConnector(DirectedInputsClass):
+        @registry.data_source(key="users", module_class="myservice")
+        def list_users(self, domain: str = None) -> dict:
+            '''List all users.'''
+            return {"user1": {...}, "user2": {...}}
+
+    # Generate Terraform modules
+    registry.generate_modules("./terraform-modules")
+
+    # Or run as external data provider
+    if __name__ == "__main__":
+        registry.run()
+
+Example usage with docstrings (legacy/compatible):
+
+    class MyDataSource(DirectedInputsClass):
+        def list_users(self, domain: str = None) -> dict:
+            '''List all users.
+
+            generator=key: users, module_class: myservice
+
+            name: domain, required: false, type: string
+            '''
+            return {"user1": {...}, "user2": {...}}
+
+    # Parse and generate
+    from python_terraform_bridge import TerraformModuleResources
+    resources = TerraformModuleResources(
+        module_name="list_users",
+        docstring=MyDataSource.list_users.__doc__,
+    )
+"""
+
+from python_terraform_bridge.module_resources import TerraformModuleResources
+from python_terraform_bridge.parameter import TerraformModuleParameter
+from python_terraform_bridge.registry import TerraformRegistry, data_source, null_resource
+from python_terraform_bridge.runtime import TerraformRuntime
+
+__all__ = [
+    "TerraformModuleParameter",
+    "TerraformModuleResources",
+    "TerraformRegistry",
+    "TerraformRuntime",
+    "data_source",
+    "null_resource",
+]
+
+__version__ = "202511.1.0"

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/__main__.py
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/__main__.py
@@ -1,0 +1,13 @@
+"""Module entry point for python-terraform-bridge.
+
+Allows running as: python -m python_terraform_bridge [options]
+"""
+
+from __future__ import annotations
+
+import sys
+
+from python_terraform_bridge.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/cli.py
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/cli.py
@@ -1,0 +1,232 @@
+"""Command-line interface for python-terraform-bridge.
+
+This module provides the `terraform-bridge` CLI command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def generate_command(args: argparse.Namespace) -> int:
+    """Handle the 'generate' subcommand.
+
+    Generates Terraform modules from a Python class.
+    """
+    from extended_data_types import get_available_methods
+
+    from python_terraform_bridge.module_resources import TerraformModuleResources
+
+    # Import the target class
+    module_path, class_name = args.target.rsplit(":", 1)
+    try:
+        import importlib
+
+        module = importlib.import_module(module_path)
+        target_class = getattr(module, class_name)
+    except (ImportError, AttributeError) as e:
+        print(f"Error importing {args.target}: {e}", file=sys.stderr)
+        return 1
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    methods = get_available_methods(target_class)
+
+    generated = 0
+    for method_name, docstring in methods.items():
+        if method_name.startswith("_"):
+            continue
+        if docstring and "NOPARSE" in docstring:
+            continue
+
+        resources = TerraformModuleResources(
+            module_name=method_name,
+            docstring=docstring,
+            terraform_modules_dir=str(output_dir),
+            terraform_modules_class=args.module_class,
+            binary_name=args.binary or "python -m python_terraform_bridge",
+        )
+
+        if resources.generation_forbidden:
+            continue
+
+        module_path = resources.get_module_path()
+        module_json = resources.get_mixed()
+
+        module_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with module_path.open("w") as f:
+            json.dump(module_json, f, indent=2)
+
+        print(f"Generated: {module_path}")
+        generated += 1
+
+    print(f"\nGenerated {generated} Terraform modules in {output_dir}")
+    return 0
+
+
+def list_command(args: argparse.Namespace) -> int:
+    """Handle the 'list' subcommand.
+
+    Lists available methods from a Python class.
+    """
+    from extended_data_types import get_available_methods
+
+    # Import the target class
+    module_path, class_name = args.target.rsplit(":", 1)
+    try:
+        import importlib
+
+        module = importlib.import_module(module_path)
+        target_class = getattr(module, class_name)
+    except (ImportError, AttributeError) as e:
+        print(f"Error importing {args.target}: {e}", file=sys.stderr)
+        return 1
+
+    methods = get_available_methods(target_class)
+
+    if args.json:
+        output: dict[str, Any] = {}
+        for name, docs in methods.items():
+            if name.startswith("_"):
+                continue
+            if docs and "NOPARSE" in docs:
+                continue
+            output[name] = docs.splitlines()[0] if docs else ""
+        print(json.dumps(output, indent=2))
+    else:
+        print(f"Methods in {args.target}:\n")
+        for name, docs in methods.items():
+            if name.startswith("_"):
+                continue
+            if docs and "NOPARSE" in docs:
+                continue
+            desc = docs.splitlines()[0] if docs else ""
+            print(f"  {name}: {desc}")
+
+    return 0
+
+
+def run_command(args: argparse.Namespace) -> int:
+    """Handle the 'run' subcommand.
+
+    Runs as a Terraform external data provider.
+    """
+    # This is for direct invocation - handled by __main__.py
+    # This subcommand provides an explicit way to run
+    import importlib
+
+    from python_terraform_bridge.runtime import TerraformRuntime
+
+    # Import the target class
+    module_path, class_name = args.target.rsplit(":", 1)
+    try:
+        module = importlib.import_module(module_path)
+        target_class = getattr(module, class_name)
+    except (ImportError, AttributeError) as e:
+        print(f"Error importing {args.target}: {e}", file=sys.stderr)
+        return 1
+
+    runtime = TerraformRuntime(data_source_class=target_class)
+
+    # Get remaining args as method name
+    method_args = args.method_args or []
+    runtime.run(method_args)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        prog="terraform-bridge",
+        description="Bridge Python classes to Terraform external data sources",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 202511.1.0",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Generate command
+    gen_parser = subparsers.add_parser(
+        "generate",
+        help="Generate Terraform modules from a Python class",
+    )
+    gen_parser.add_argument(
+        "target",
+        help="Python class to generate from (e.g., mymodule:MyClass)",
+    )
+    gen_parser.add_argument(
+        "-o",
+        "--output",
+        default="terraform-modules",
+        help="Output directory for generated modules",
+    )
+    gen_parser.add_argument(
+        "-c",
+        "--module-class",
+        default="",
+        help="Module class prefix",
+    )
+    gen_parser.add_argument(
+        "-b",
+        "--binary",
+        default=None,
+        help="Binary command for runtime invocation",
+    )
+
+    # List command
+    list_parser = subparsers.add_parser(
+        "list",
+        help="List available methods from a Python class",
+    )
+    list_parser.add_argument(
+        "target",
+        help="Python class to inspect (e.g., mymodule:MyClass)",
+    )
+    list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+
+    # Run command
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Run as Terraform external data provider",
+    )
+    run_parser.add_argument(
+        "target",
+        help="Python class to run (e.g., mymodule:MyClass)",
+    )
+    run_parser.add_argument(
+        "method_args",
+        nargs="*",
+        help="Method name (parts separated by spaces become underscores)",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    if args.command == "generate":
+        return generate_command(args)
+    elif args.command == "list":
+        return list_command(args)
+    elif args.command == "run":
+        return run_command(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/module_resources.py
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/module_resources.py
@@ -1,0 +1,679 @@
+"""Terraform module resources generation.
+
+This module provides the TerraformModuleResources class for generating
+Terraform module JSON from Python class methods.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import time
+from copy import deepcopy
+from pathlib import Path
+from shlex import split as shlex_split
+from typing import Any
+
+from extended_data_types import is_nothing, strtobool
+from tssplit import tssplit
+
+from python_terraform_bridge.parameter import TerraformModuleParameter
+
+
+def get_json_export_for_chunk(chunk: str) -> tuple[str, Any]:
+    """Parse a key:value chunk from docstring annotation."""
+    try:
+        # Split only on first colon to handle values like "hashicorp/aws"
+        k, v = chunk.strip().strip('"').split(":", 1)
+    except ValueError as exc:
+        raise RuntimeError(f"Failed to get chunks for: {chunk}") from exc
+
+    k = k.strip().strip('"')
+    v = v.strip().strip('"')
+
+    try:
+        return k, json.loads(v)
+    except json.JSONDecodeError:
+        return k, v
+
+
+def drop_empty_blocks(data_blocks: dict[str, Any]) -> dict[str, Any]:
+    """Remove empty values from a dictionary."""
+    return {k: v for k, v in data_blocks.items() if not is_nothing(v)}
+
+
+class TerraformModuleResources:
+    """Generate Terraform module resources from Python methods.
+
+    This class parses docstring annotations to generate Terraform external_data
+    and null_resource modules that call back to Python.
+
+    Docstring format:
+        '''Short description.
+
+        generator=key: output_key, module_class: aws
+
+        name: param1, required: true, type: string
+        name: param2, required: false, type: string, default: "value"
+        '''
+
+    Attributes:
+        module_name: Name of the Python method.
+        module_type: Type of module (data_source or null_resource).
+        docstring: The method's docstring with annotations.
+    """
+
+    # Default settings - can be overridden
+    DEFAULT_MODULES_DIR = "terraform-modules"
+    DEFAULT_NAME_DELIM = "-"
+    DEFAULT_BINARY_NAME = "python -m python_terraform_bridge"
+
+    def __init__(
+        self,
+        module_name: str,
+        docstring: str | None,
+        module_type: str | None = None,
+        module_params: Any = None,
+        terraform_modules_dir: str | None = None,
+        terraform_modules_class: str | None = None,
+        terraform_modules_name_delim: str | None = None,
+        binary_name: str | None = None,
+    ):
+        """Initialize TerraformModuleResources.
+
+        Args:
+            module_name: Name of the method/module.
+            docstring: Method docstring with annotations.
+            module_type: Override module type (data_source, null_resource).
+            module_params: Pre-parsed parameters.
+            terraform_modules_dir: Output directory for modules.
+            terraform_modules_class: Module class prefix.
+            terraform_modules_name_delim: Delimiter for module names.
+            binary_name: Command to invoke the Python runtime.
+        """
+        self.terraform_modules_dir = terraform_modules_dir or self.DEFAULT_MODULES_DIR
+        self.terraform_modules_name_delim = terraform_modules_name_delim or self.DEFAULT_NAME_DELIM
+        self.binary_name = binary_name or self.DEFAULT_BINARY_NAME
+
+        if terraform_modules_class is None:
+            terraform_modules_class = ""
+
+        self.terraform_modules_class = terraform_modules_class.removesuffix(
+            self.terraform_modules_name_delim
+        )
+
+        self.module_name = module_name
+        self.module_type = module_type
+        self.docstring = docstring
+        self.descriptor: str | None = None
+        self.module_parameters: list[TerraformModuleParameter] = []
+        self.generator_parameters: dict[str, Any] = {}
+        self.extra_outputs: dict[str, dict[str, Any]] = {}
+        self.sub_keys: dict[str, dict[str, Any]] = {}
+
+        # Environment variable definitions
+        self.env_variables: dict[str, dict[str, Any]] = {}
+        self.sensitive_env_variables: dict[str, dict[str, Any]] = {}
+
+        self.required_providers: dict[str, dict[str, str]] = {
+            "env": {
+                "source": "tcarreira/env",
+                "version": ">=0.2.0",
+            }
+        }
+
+        self.copy_variables_to: list[dict[str, Any]] = []
+        self.module_parameter_names: set[str] = set()
+        self.foreach_modules: dict[Path, str] = {}
+        self.foreach_iterator: TerraformModuleParameter | None = None
+        self.foreach_from_file_path: TerraformModuleParameter | None = None
+        self.foreach_keys: list[str] = []
+        self.foreach_values: list[str] = []
+        self.foreach_only: list[str] = []
+        self.foreach_forbidden: list[str] = []
+        self.generation_forbidden: bool = False
+        self.foreach_bind_log_file_name_to_key: bool = False
+
+        self.call = f"{self.binary_name} {self.module_name}"
+
+        self.get_module_config()
+        self.set_module_params(module_params)
+        self.set_required_module_params()
+
+    def get_module_config(self) -> None:
+        """Parse docstring to extract module configuration."""
+        if self.docstring is None:
+            return
+
+        docstring = [line for line in self.docstring.splitlines() if line != ""]
+
+        if len(docstring) == 0:
+            return
+
+        self.descriptor = docstring.pop(0)
+
+        if len(docstring) == 0:
+            return
+
+        module_params: list[Any] = []
+
+        def split_param(p: str) -> list[str]:
+            return tssplit(
+                p,
+                quote='"',
+                quote_keep=True,
+                delimiter=",",
+            )
+
+        for param in docstring:
+            try:
+                param = param.strip()
+                if is_nothing(param):
+                    continue
+
+                if param.startswith("#"):
+                    comment = param.lstrip("#").strip().lower()
+                    if comment == "noterraform":
+                        self.generation_forbidden = True
+                    continue
+
+                if param.startswith("generator="):
+                    chunks = split_param(param.removeprefix("generator="))
+                    for chunk in chunks:
+                        k, v = get_json_export_for_chunk(chunk)
+                        if k == "plaintext_output":
+                            self.generator_parameters[k] = strtobool(v)
+                        else:
+                            self.generator_parameters[k] = v
+                    continue
+
+                if param.startswith("env="):
+                    chunks = split_param(param.removeprefix("env="))
+                    processed_chunks: dict[str, Any] = {}
+                    env_name = None
+                    for chunk in chunks:
+                        k, v = get_json_export_for_chunk(chunk)
+                        if k == "name":
+                            env_name = v
+                        else:
+                            processed_chunks[k] = strtobool(v) if k == "required" else v
+
+                    if not env_name:
+                        raise ValueError(f"Environment variable {param} is missing its name")
+                    if processed_chunks.get("sensitive", False):
+                        self.sensitive_env_variables[env_name] = processed_chunks
+                    else:
+                        self.env_variables[env_name] = processed_chunks
+                    continue
+
+                if param.startswith("extra_output="):
+                    chunks = split_param(param.removeprefix("extra_output="))
+                    extra_output: dict[str, Any] = {}
+                    for chunk in chunks:
+                        k, v = get_json_export_for_chunk(chunk)
+                        extra_output[k] = v
+
+                    extra_output_key = extra_output.pop("key", None)
+                    if is_nothing(extra_output_key):
+                        raise RuntimeError(f"Extra output missing key: {param}")
+
+                    self.extra_outputs[extra_output_key] = extra_output
+                    continue
+
+                if param.startswith("sub_key="):
+                    chunks = split_param(param.removeprefix("sub_key="))
+                    sub_key: dict[str, Any] = {}
+                    for chunk in chunks:
+                        k, v = get_json_export_for_chunk(chunk)
+                        sub_key[k] = v
+
+                    sub_key_key = sub_key.pop("key", None)
+                    if is_nothing(sub_key_key):
+                        raise RuntimeError(f"Sub key missing key: {param}")
+
+                    self.sub_keys[sub_key_key] = sub_key
+                    continue
+
+                if param.startswith("required_provider="):
+                    chunks = split_param(param.removeprefix("required_provider="))
+                    required_provider: dict[str, Any] = {}
+                    for chunk in chunks:
+                        k, v = get_json_export_for_chunk(chunk)
+                        required_provider[k] = v
+
+                    provider_name = required_provider.pop("name", None)
+                    if is_nothing(provider_name):
+                        raise RuntimeError(f"Required provider missing name: {param}")
+
+                    self.required_providers[provider_name] = required_provider
+                    continue
+
+                if param.startswith("copy_variables_to="):
+                    chunks = split_param(param.removeprefix("copy_variables_to="))
+                    copy_variables_to: dict[str, Any] = {}
+                    for chunk in chunks:
+                        k, v = get_json_export_for_chunk(chunk)
+                        copy_variables_to[k] = v
+
+                    self.copy_variables_to.append(copy_variables_to)
+                    continue
+
+                if param.startswith("foreach="):
+                    chunks = split_param(param.removeprefix("foreach="))
+                    foreach_module_name = f"{self.module_name}s"
+                    foreach_module_call = self.module_name
+                    foreach_bind_log_file_name_to_key = False
+
+                    for chunk in chunks:
+                        k, v = get_json_export_for_chunk(chunk)
+                        if k == "module_name":
+                            foreach_module_name = v
+                        elif k == "module_call":
+                            foreach_module_call = v
+                        elif k == "bind_log_file_name_to_key":
+                            foreach_bind_log_file_name_to_key = strtobool(v)
+
+                    foreach_module_path = self.get_module_path(module_name=foreach_module_name)
+                    self.foreach_modules[foreach_module_path] = self.get_module_name(
+                        module_name=foreach_module_call
+                    )
+                    self.foreach_bind_log_file_name_to_key = foreach_bind_log_file_name_to_key
+                    continue
+
+                # Parse regular parameter
+                expanded_param: dict[str, Any] = {}
+                chunks = split_param(param)
+
+                found_foreach_iterator = False
+                found_foreach_key = False
+                found_foreach_value = False
+                found_foreach_from_file_path = False
+                foreach_only = False
+                foreach_forbidden = False
+
+                for chunk in chunks:
+                    k, v = get_json_export_for_chunk(chunk)
+                    if k == "foreach_iterator":
+                        found_foreach_iterator = True
+                    elif k == "foreach_from_file_path":
+                        found_foreach_from_file_path = True
+                    elif k == "foreach_key":
+                        found_foreach_key = True
+                    elif k == "foreach_value":
+                        found_foreach_value = True
+                    elif k == "foreach_only":
+                        foreach_only = True
+                    elif k == "foreach_forbidden":
+                        foreach_forbidden = True
+                    else:
+                        expanded_param[k] = v
+
+                try:
+                    module_param = TerraformModuleParameter(**expanded_param)
+                except TypeError as exc:
+                    raise RuntimeError(f"Failed to generate parameter: {expanded_param}") from exc
+
+                module_params.append(module_param)
+
+                if found_foreach_iterator:
+                    self.foreach_iterator = module_param
+                if found_foreach_from_file_path:
+                    self.foreach_from_file_path = module_param
+                if found_foreach_key:
+                    self.foreach_keys.append(module_param.name)
+                if found_foreach_value:
+                    self.foreach_values.append(module_param.name)
+                if foreach_only:
+                    self.foreach_only.append(module_param.name)
+                    continue
+                if foreach_forbidden:
+                    self.foreach_forbidden.append(module_param.name)
+                    continue
+
+                module_params.append(expanded_param)
+
+            except RuntimeError as exc:
+                raise RuntimeError(f"Failed to parse docstring param: {param}") from exc
+
+        self.set_module_params(module_params)
+
+    def set_module_params(self, module_params: Any) -> None:
+        """Set module parameters from parsed config."""
+        if module_params is None:
+            return
+
+        for module_param in module_params:
+            if not isinstance(module_param, TerraformModuleParameter):
+                module_param = TerraformModuleParameter(**module_param)
+
+            self.module_parameters.append(module_param)
+            self.module_parameter_names.add(module_param.name)
+
+    def set_required_module_params(self) -> None:
+        """Add required standard parameters."""
+        required_params = {
+            "checksum": TerraformModuleParameter(
+                name="checksum",
+                default="",
+                required=False,
+                description="Optional checksum to use for triggering resource updates",
+            ),
+        }
+
+        for param_name, module_param in required_params.items():
+            if param_name not in self.module_parameter_names:
+                self.module_parameters.append(module_param)
+                self.module_parameter_names.add(param_name)
+
+    def get_variables(
+        self,
+        filter_foreach_only: bool = True,
+        filter_foreach_forbidden: bool = False,
+    ) -> dict[str, dict[str, Any]]:
+        """Generate Terraform variable blocks."""
+        variables: dict[str, dict[str, Any]] = {}
+
+        for param in self.module_parameters:
+            if filter_foreach_only and param.name in self.foreach_only:
+                continue
+            if filter_foreach_forbidden and param.name in self.foreach_forbidden:
+                continue
+
+            variables[param.name] = param.get_variable()
+
+        return variables
+
+    def get_triggers(
+        self,
+        disable_encoding: bool = False,
+        filter_foreach_only: bool = True,
+        filter_foreach_forbidden: bool = False,
+    ) -> dict[str, str]:
+        """Generate Terraform trigger expressions."""
+        triggers: dict[str, str] = {}
+
+        for param in self.module_parameters:
+            if filter_foreach_only and param.name in self.foreach_only:
+                continue
+            if filter_foreach_forbidden and param.name in self.foreach_forbidden:
+                continue
+
+            triggers[param.name] = param.get_trigger(disable_encoding)
+
+        if strtobool(self.generator_parameters.get("always", False)):
+            triggers["always"] = "${timestamp()}"
+
+        return triggers
+
+    def get_terraform(
+        self,
+        provider_type: str | None = None,
+        provider_min_version: str | None = None,
+        provider_organization: str = "hashicorp",
+        terraform_min_version: str = "1.6",
+    ) -> dict[str, Any]:
+        """Generate terraform block with required providers."""
+        terraform: dict[str, Any] = {
+            "required_version": f">={terraform_min_version}",
+        }
+
+        terraform_providers = deepcopy(self.required_providers)
+
+        if not is_nothing(provider_type):
+            terraform_providers[provider_type] = {
+                "source": f"{provider_organization}/{provider_type}",
+            }
+            if not is_nothing(provider_min_version):
+                terraform_providers[provider_type]["version"] = f">={provider_min_version}"
+
+        if not is_nothing(terraform_providers):
+            terraform["required_providers"] = terraform_providers
+
+        return terraform
+
+    def get_external_data(
+        self,
+        key: str | None = None,
+        output_description: str = "Data query results",
+    ) -> dict[str, Any]:
+        """Generate external_data Terraform module."""
+        if key is None:
+            key = self.generator_parameters.get("key")
+
+        if is_nothing(key):
+            raise RuntimeError("Cannot generate external data module without a data key")
+
+        query = self.get_triggers()
+
+        # Add environment variable references
+        for env_name in self.env_variables:
+            query[env_name] = f"${{data.env_var.{env_name}.value}}"
+        for env_name in self.sensitive_env_variables:
+            query[env_name] = f"${{data.env_sensitive.{env_name}.value}}"
+
+        external_data = {"program": shlex_split(self.call), "query": query}
+
+        data_blocks = drop_empty_blocks(
+            {
+                "external": {"default": external_data},
+                "env_var": {
+                    env_name: {"id": env_name, "required": env_data.get("required", False)}
+                    for env_name, env_data in self.env_variables.items()
+                },
+                "env_sensitive": {
+                    env_name: {"id": env_name, "required": env_data.get("required", False)}
+                    for env_name, env_data in self.sensitive_env_variables.items()
+                },
+            }
+        )
+
+        # Determine output expression
+        if self.generator_parameters.get("plaintext_output", False):
+            results_expr = '${data.external.default.result["' + key + '"]}'
+        else:
+            results_expr = (
+                '${jsondecode(base64decode(data.external.default.result["' + key + '"]))}'
+            )
+
+        tf_json = drop_empty_blocks(
+            {
+                "terraform": self.get_terraform("external", "2.3.1"),
+                "variable": self.get_variables(),
+                "data": data_blocks,
+                "locals": {"results": results_expr},
+                "output": {
+                    key: {
+                        "value": "${local.results}",
+                        "description": output_description,
+                    }
+                },
+            }
+        )
+
+        # Add extra outputs
+        for extra_key, _extra_config in self.extra_outputs.items():
+            tf_json["locals"][extra_key] = (
+                '${jsondecode(base64decode(data.external.default.result["' + extra_key + '"]))}'
+            )
+            tf_json["output"][extra_key] = {
+                "value": "${local." + extra_key + "}",
+                "description": output_description,
+            }
+
+        # Add sub-key outputs
+        for sub_key_key, sub_key_config in self.sub_keys.items():
+            sub_key_value = f"local.results.{sub_key_key}"
+
+            if sub_key_config.get("base64_encode", False):
+                sub_key_value = "base64decode(" + sub_key_value + ")"
+            if sub_key_config.get("json_encode", False):
+                sub_key_value = "jsondecode(" + sub_key_value + ")"
+            if sub_key_config.get("yaml_encode", False):
+                sub_key_value = "yamlencode(" + sub_key_value + ")"
+
+            sub_key_value = "${" + sub_key_value + "}"
+
+            tf_json["output"][sub_key_key] = {
+                "value": sub_key_value,
+                "description": output_description,
+            }
+
+        return tf_json
+
+    def get_null_resource(self, provisioner_type: str | None = None) -> dict[str, Any]:
+        """Generate null_resource (terraform_data) Terraform module."""
+        provisioner_type = provisioner_type or self.generator_parameters.get("provisioner_type")
+        if provisioner_type is None:
+            provisioner_type = "local-exec"
+
+        triggers = self.get_triggers()
+
+        environment = {
+            name: "${self.triggers_replace." + name + "}" for name in triggers if name != "script"
+        }
+
+        # Add environment variable references
+        for env_name in self.env_variables:
+            environment[env_name] = f"${{data.env_var.{env_name}.value}}"
+        for env_name in self.sensitive_env_variables:
+            environment[env_name] = f"${{data.env_sensitive.{env_name}.value}}"
+
+        provisioner = {"command": self.call, "environment": environment}
+        provisioner_block = [{provisioner_type: provisioner}]
+
+        null_resource = {
+            "triggers_replace": triggers,
+            "provisioner": provisioner_block,
+        }
+
+        data_blocks = drop_empty_blocks(
+            {
+                "env_var": {
+                    env_name: {"id": env_name, "required": env_data.get("required", False)}
+                    for env_name, env_data in self.env_variables.items()
+                },
+                "env_sensitive": {
+                    env_name: {"id": env_name, "required": env_data.get("required", False)}
+                    for env_name, env_data in self.sensitive_env_variables.items()
+                },
+            }
+        )
+
+        return drop_empty_blocks(
+            {
+                "terraform": self.get_terraform(),
+                "variable": self.get_variables(),
+                "resource": {"terraform_data": {"default": null_resource}},
+                "data": data_blocks,
+            }
+        )
+
+    def get_mixed(self, module_type: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        """Generate module based on type."""
+        if module_type is None:
+            module_type = self.module_type
+
+        if module_type is None:
+            module_type = self.generator_parameters.get("type", "data_source")
+
+        if module_type == "data_source":
+            return self.get_external_data(**kwargs)
+        elif module_type == "null_resource":
+            return self.get_null_resource(**kwargs)
+        else:
+            raise RuntimeError(f"Unknown module type: {module_type}")
+
+    def get_module_class(self, module_class: str | None = None) -> str | None:
+        """Get the module class for path construction."""
+        import re
+
+        if is_nothing(module_class):
+            return self.generator_parameters.get("module_class", self.terraform_modules_class)
+
+        if not module_class[:1].isalnum():
+            first_alpha = re.search(r"[A-Za-z0-9]", module_class)
+            if not first_alpha:
+                return None
+
+        return module_class
+
+    def get_module_name(
+        self,
+        module_class: str | None = None,
+        module_name: str | None = None,
+    ) -> str:
+        """Get the full module name."""
+        module_class = self.get_module_class(module_class)
+
+        if is_nothing(module_class) or strtobool(
+            self.generator_parameters.get("no_class_in_module_name", False)
+        ):
+            chunks = []
+        else:
+            chunks = [module_class]
+
+        if is_nothing(module_name):
+            chunks.append(self.module_name)
+        else:
+            chunks.append(module_name)
+
+        return self.terraform_modules_name_delim.join(chunks).replace(
+            "_", self.terraform_modules_name_delim
+        )
+
+    def get_module_path(
+        self,
+        modules_dir: str | None = None,
+        module_class: str | None = None,
+        module_name: str | None = None,
+        modules_file_name: str = "main.tf.json",
+    ) -> Path:
+        """Get the file path for the module."""
+        if is_nothing(modules_dir):
+            modules_dir = self.terraform_modules_dir
+
+        modules_dir = Path(modules_dir)
+
+        module_class = self.get_module_class(module_class=module_class)
+        module_name = self.get_module_name(module_class=module_class, module_name=module_name)
+
+        if module_class == module_name:
+            return modules_dir.joinpath(module_name, modules_file_name)
+
+        return modules_dir.joinpath(module_class, module_name, modules_file_name)
+
+    @classmethod
+    def get_all_resources(
+        cls,
+        terraform_modules: dict[str, str],
+        **kwargs: Any,
+    ) -> tuple[list[TerraformModuleResources], float]:
+        """Generate resources for all modules in parallel.
+
+        Args:
+            terraform_modules: Dict mapping method names to docstrings.
+            **kwargs: Additional arguments for TerraformModuleResources.
+
+        Returns:
+            Tuple of (list of resources, elapsed time).
+        """
+        resources: list[TerraformModuleResources] = []
+
+        tic = time.perf_counter()
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = []
+
+            for module_name, module_docs in terraform_modules.items():
+                futures.append(
+                    executor.submit(cls, module_name=module_name, docstring=module_docs, **kwargs)
+                )
+
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    resources.append(future.result())
+                except Exception as exc:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    raise RuntimeError("Failed to get resources") from exc
+
+        toc = time.perf_counter()
+        return resources, toc - tic

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/parameter.py
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/parameter.py
@@ -1,0 +1,163 @@
+"""Terraform module parameter definition.
+
+This module provides the TerraformModuleParameter class for defining
+input parameters for Terraform modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class TerraformModuleParameter:
+    """Represents a parameter for a Terraform module.
+
+    This class handles the translation between Python function parameters
+    and Terraform variable definitions.
+
+    Attributes:
+        name: Parameter name.
+        json_encode: Whether to JSON encode the value in triggers.
+        base64_encode: Whether to base64 encode the value in triggers.
+        default: Default value for the parameter.
+        required: Whether the parameter is required.
+        description: Human-readable description.
+        sensitive: Whether the value is sensitive (masked in logs).
+        type: Terraform type (string, bool, number, any, map, list).
+        trigger: Custom trigger expression override.
+    """
+
+    name: str
+    json_encode: bool = field(default=False)
+    base64_encode: bool = field(default=False)
+    default: Any = field(default=None)
+    required: bool = field(default=True)
+    description: str | None = field(default=None)
+    sensitive: bool = field(default=False)
+    type: str | None = field(default=None)
+    trigger: str | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        """Infer type from default value if not specified."""
+        if self.type is not None:
+            return
+
+        if isinstance(self.default, str) or self.name.endswith("id"):
+            self.type = "string"
+        elif isinstance(self.default, bool):
+            self.type = "bool"
+        elif isinstance(self.default, int):
+            self.type = "number"
+        elif isinstance(self.default, list):
+            self.type = "list(any)"
+        elif isinstance(self.default, dict):
+            self.type = "map(any)"
+        else:
+            self.type = "any"
+
+    def get_variable(self) -> dict[str, Any]:
+        """Generate Terraform variable block.
+
+        Returns:
+            Dictionary suitable for Terraform JSON variable definition.
+        """
+        variable: dict[str, Any] = {"type": self.type}
+
+        if not self.required:
+            variable["default"] = self.default
+
+        if self.description is not None:
+            variable["description"] = self.description
+
+        if self.sensitive:
+            variable["sensitive"] = True
+
+        return variable
+
+    def get_trigger(self, disable_encoding: bool = False) -> str:
+        """Generate Terraform trigger expression.
+
+        Args:
+            disable_encoding: Skip JSON/base64 encoding.
+
+        Returns:
+            Terraform expression string for use in triggers.
+        """
+        if self.trigger is not None:
+            return self.trigger
+
+        trigger = f"var.{self.name}"
+
+        if self.json_encode and not disable_encoding:
+            trigger = f"jsonencode({trigger})"
+
+        if self.base64_encode and not disable_encoding:
+            trigger = f"base64encode({trigger})"
+
+        return "${try(nonsensitive(" + trigger + "), " + trigger + ")}"
+
+    @classmethod
+    def from_type_hint(
+        cls,
+        name: str,
+        type_hint: Any,
+        default: Any = None,
+        description: str | None = None,
+    ) -> TerraformModuleParameter:
+        """Create parameter from Python type hint.
+
+        Args:
+            name: Parameter name.
+            type_hint: Python type annotation.
+            default: Default value.
+            description: Parameter description.
+
+        Returns:
+            TerraformModuleParameter instance.
+        """
+        import inspect
+        from typing import get_origin
+
+        # Determine if required based on default
+        required = default is inspect.Parameter.empty
+
+        # Infer encoding from type hints
+        json_encode = False
+        base64_encode = False
+        tf_type = "any"
+
+        origin = get_origin(type_hint)
+
+        # Handle basic types
+        if type_hint is str:
+            tf_type = "string"
+        elif type_hint is bool:
+            tf_type = "bool"
+        elif type_hint is int or type_hint is float:
+            tf_type = "number"
+        # Handle generic types (List[x], Dict[k,v], etc.)
+        elif origin is list:
+            tf_type = "list(any)"
+        elif origin is dict:
+            tf_type = "map(any)"
+            json_encode = True
+            base64_encode = True
+        # Handle bare list/dict without generics
+        elif type_hint is list:
+            tf_type = "list(any)"
+        elif type_hint is dict:
+            tf_type = "map(any)"
+            json_encode = True
+            base64_encode = True
+
+        return cls(
+            name=name,
+            json_encode=json_encode,
+            base64_encode=base64_encode,
+            default=None if required else default,
+            required=required,
+            description=description,
+            type=tf_type,
+        )

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/py.typed
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/py.typed
@@ -1,0 +1,1 @@
+# PEP 561 marker file

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/registry.py
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/registry.py
@@ -1,0 +1,461 @@
+"""Terraform method registry with decorator-based registration.
+
+This module provides a modern decorator-based approach for registering
+methods as Terraform data sources or null resources.
+
+Example:
+    from python_terraform_bridge import TerraformRegistry, data_source
+
+    registry = TerraformRegistry()
+
+    class MyService(DirectedInputsClass):
+        @registry.data_source(key="users", module_class="myservice")
+        def list_users(self, domain: str = None) -> dict:
+            '''List all users in the organization.'''
+            return {"user1": {...}, "user2": {...}}
+
+    # Generate Terraform modules
+    registry.generate_modules("./terraform-modules")
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path  # noqa: TC003 - used at runtime for Path.open()
+from typing import Any, TypeVar
+
+from python_terraform_bridge.module_resources import TerraformModuleResources
+from python_terraform_bridge.parameter import TerraformModuleParameter
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+@dataclass
+class TerraformMethodConfig:
+    """Configuration for a registered Terraform method.
+
+    Attributes:
+        method: The original method.
+        method_name: Name of the method.
+        module_type: Type of Terraform module (data_source, null_resource).
+        key: Output key name.
+        module_class: Module class/namespace prefix.
+        description: Short description.
+        parameters: List of parameter definitions.
+        env_variables: Environment variables to read.
+        sensitive_env_variables: Sensitive environment variables.
+        extra_outputs: Additional output keys.
+        required_providers: Additional Terraform providers.
+        generation_forbidden: Whether to skip module generation.
+        always_run: Whether to always trigger execution.
+        plaintext_output: Whether output is plaintext (vs base64 JSON).
+    """
+
+    method: Callable[..., Any]
+    method_name: str
+    module_type: str = "data_source"
+    key: str | None = None
+    module_class: str | None = None
+    description: str | None = None
+    parameters: list[TerraformModuleParameter] = field(default_factory=list)
+    env_variables: dict[str, dict[str, Any]] = field(default_factory=dict)
+    sensitive_env_variables: dict[str, dict[str, Any]] = field(default_factory=dict)
+    extra_outputs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    required_providers: dict[str, dict[str, str]] = field(default_factory=dict)
+    generation_forbidden: bool = False
+    always_run: bool = False
+    plaintext_output: bool = False
+
+    def __post_init__(self) -> None:
+        """Extract description from docstring if not provided."""
+        if self.description is None and self.method.__doc__:
+            # First line of docstring
+            self.description = self.method.__doc__.strip().split("\n")[0]
+
+        if self.key is None:
+            self.key = self.method_name
+
+    def to_module_resources(
+        self,
+        terraform_modules_dir: str = "terraform-modules",
+        binary_name: str = "python -m python_terraform_bridge",
+    ) -> TerraformModuleResources:
+        """Convert to TerraformModuleResources.
+
+        Args:
+            terraform_modules_dir: Output directory for modules.
+            binary_name: Command to invoke the Python runtime.
+
+        Returns:
+            TerraformModuleResources instance.
+        """
+        # Build generator parameters
+        generator_params = {
+            "key": self.key,
+            "type": self.module_type,
+            "plaintext_output": self.plaintext_output,
+        }
+        if self.always_run:
+            generator_params["always"] = True
+
+        # Build docstring for compatibility
+        docstring_lines = [self.description or ""]
+        docstring_lines.append(
+            f"generator=key: {self.key}, type: {self.module_type}"
+            + (f", module_class: {self.module_class}" if self.module_class else "")
+        )
+
+        for param in self.parameters:
+            parts = [f"name: {param.name}"]
+            if param.type:
+                parts.append(f"type: {param.type}")
+            if not param.required:
+                parts.append("required: false")
+                if param.default is not None:
+                    parts.append(f'default: "{param.default}"')
+            if param.description:
+                parts.append(f'description: "{param.description}"')
+            if param.sensitive:
+                parts.append("sensitive: true")
+            docstring_lines.append(", ".join(parts))
+
+        for env_name, env_config in self.env_variables.items():
+            parts = [f"name: {env_name}"]
+            if env_config.get("required"):
+                parts.append("required: true")
+            docstring_lines.append("env=" + ", ".join(parts))
+
+        for env_name, env_config in self.sensitive_env_variables.items():
+            parts = [f"name: {env_name}", "sensitive: true"]
+            if env_config.get("required"):
+                parts.append("required: true")
+            docstring_lines.append("env=" + ", ".join(parts))
+
+        docstring = "\n".join(docstring_lines)
+
+        resources = TerraformModuleResources(
+            module_name=self.method_name,
+            docstring=docstring,
+            module_type=self.module_type,
+            terraform_modules_dir=terraform_modules_dir,
+            terraform_modules_class=self.module_class,
+            binary_name=binary_name,
+        )
+
+        # Override with explicit settings
+        resources.generator_parameters.update(generator_params)
+        resources.extra_outputs.update(self.extra_outputs)
+        resources.required_providers.update(self.required_providers)
+        resources.generation_forbidden = self.generation_forbidden
+
+        return resources
+
+
+class TerraformRegistry:
+    """Registry for Terraform-enabled methods.
+
+    This class maintains a registry of methods that can be exposed as
+    Terraform external data sources or null resources.
+
+    Example:
+        registry = TerraformRegistry()
+
+        class MyService(DirectedInputsClass):
+            @registry.data_source(key="users")
+            def list_users(self) -> dict:
+                return {}
+
+        # Generate modules
+        registry.generate_modules("./modules")
+
+        # Or run as CLI
+        registry.run()
+    """
+
+    def __init__(self, name: str = "default") -> None:
+        """Initialize the registry.
+
+        Args:
+            name: Registry name for identification.
+        """
+        self.name = name
+        self._methods: dict[str, TerraformMethodConfig] = {}
+
+    def register(
+        self,
+        method_name: str | None = None,
+        module_type: str = "data_source",
+        key: str | None = None,
+        module_class: str | None = None,
+        description: str | None = None,
+        parameters: list[TerraformModuleParameter] | None = None,
+        env_variables: dict[str, dict[str, Any]] | None = None,
+        sensitive_env_variables: dict[str, dict[str, Any]] | None = None,
+        extra_outputs: dict[str, dict[str, Any]] | None = None,
+        required_providers: dict[str, dict[str, str]] | None = None,
+        generation_forbidden: bool = False,
+        always_run: bool = False,
+        plaintext_output: bool = False,
+    ) -> Callable[[F], F]:
+        """Register a method with the Terraform bridge.
+
+        Args:
+            method_name: Override method name.
+            module_type: Type of module (data_source, null_resource).
+            key: Output key name.
+            module_class: Module class prefix.
+            description: Short description.
+            parameters: Parameter definitions (auto-inferred if None).
+            env_variables: Environment variables.
+            sensitive_env_variables: Sensitive environment variables.
+            extra_outputs: Additional outputs.
+            required_providers: Additional providers.
+            generation_forbidden: Skip module generation.
+            always_run: Always trigger execution.
+            plaintext_output: Output as plaintext.
+
+        Returns:
+            Decorator function.
+        """
+
+        def decorator(func: F) -> F:
+            nonlocal method_name, parameters
+
+            if method_name is None:
+                method_name = func.__name__
+
+            # Auto-infer parameters from signature
+            if parameters is None:
+                parameters = self._infer_parameters(func)
+
+            config = TerraformMethodConfig(
+                method=func,
+                method_name=method_name,
+                module_type=module_type,
+                key=key or method_name,
+                module_class=module_class,
+                description=description,
+                parameters=parameters or [],
+                env_variables=env_variables or {},
+                sensitive_env_variables=sensitive_env_variables or {},
+                extra_outputs=extra_outputs or {},
+                required_providers=required_providers or {},
+                generation_forbidden=generation_forbidden,
+                always_run=always_run,
+                plaintext_output=plaintext_output,
+            )
+
+            self._methods[method_name] = config
+
+            @functools.wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
+
+            # Attach registry info to wrapper
+            wrapper._terraform_config = config  # type: ignore
+            return wrapper  # type: ignore
+
+        return decorator
+
+    def data_source(
+        self,
+        key: str | None = None,
+        module_class: str | None = None,
+        **kwargs: Any,
+    ) -> Callable[[F], F]:
+        """Register a method as a Terraform data source.
+
+        Args:
+            key: Output key name.
+            module_class: Module class prefix.
+            **kwargs: Additional registration options.
+
+        Returns:
+            Decorator function.
+        """
+        return self.register(
+            module_type="data_source",
+            key=key,
+            module_class=module_class,
+            **kwargs,
+        )
+
+    def null_resource(
+        self,
+        module_class: str | None = None,
+        **kwargs: Any,
+    ) -> Callable[[F], F]:
+        """Register a method as a Terraform null_resource.
+
+        Args:
+            module_class: Module class prefix.
+            **kwargs: Additional registration options.
+
+        Returns:
+            Decorator function.
+        """
+        return self.register(
+            module_type="null_resource",
+            module_class=module_class,
+            **kwargs,
+        )
+
+    def _infer_parameters(
+        self,
+        func: Callable[..., Any],
+    ) -> list[TerraformModuleParameter]:
+        """Infer Terraform parameters from function signature.
+
+        Args:
+            func: Function to inspect.
+
+        Returns:
+            List of inferred parameters.
+        """
+        sig = inspect.signature(func)
+        hints = getattr(func, "__annotations__", {})
+        parameters = []
+
+        for name, param in sig.parameters.items():
+            if name in ("self", "cls"):
+                continue
+
+            type_hint = hints.get(name, str)
+
+            parameters.append(
+                TerraformModuleParameter.from_type_hint(
+                    name=name,
+                    type_hint=type_hint,
+                    default=param.default,
+                )
+            )
+
+        return parameters
+
+    def get_method(self, method_name: str) -> TerraformMethodConfig | None:
+        """Get a registered method by name.
+
+        Args:
+            method_name: Name of the method.
+
+        Returns:
+            Method configuration or None.
+        """
+        return self._methods.get(method_name)
+
+    def list_methods(self) -> dict[str, str]:
+        """List all registered methods with descriptions.
+
+        Returns:
+            Dict mapping method names to descriptions.
+        """
+        return {name: config.description or "" for name, config in self._methods.items()}
+
+    def generate_modules(
+        self,
+        output_dir: str = "terraform-modules",
+        binary_name: str = "python -m python_terraform_bridge",
+    ) -> dict[str, Path]:
+        """Generate Terraform modules for all registered methods.
+
+        Args:
+            output_dir: Directory to write modules.
+            binary_name: Command to invoke the runtime.
+
+        Returns:
+            Dict mapping method names to generated module paths.
+        """
+        generated: dict[str, Path] = {}
+
+        for name, config in self._methods.items():
+            if config.generation_forbidden:
+                continue
+
+            resources = config.to_module_resources(
+                terraform_modules_dir=output_dir,
+                binary_name=binary_name,
+            )
+
+            module_path = resources.get_module_path()
+            module_json = resources.get_mixed()
+
+            # Ensure directory exists
+            module_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Write module
+            with module_path.open("w") as f:
+                json.dump(module_json, f, indent=2)
+
+            generated[name] = module_path
+
+        return generated
+
+    def get_all_resources(
+        self,
+        terraform_modules_dir: str = "terraform-modules",
+        binary_name: str = "python -m python_terraform_bridge",
+    ) -> list[TerraformModuleResources]:
+        """Get TerraformModuleResources for all registered methods.
+
+        Args:
+            terraform_modules_dir: Output directory for modules.
+            binary_name: Command to invoke the runtime.
+
+        Returns:
+            List of TerraformModuleResources instances.
+        """
+        return [
+            config.to_module_resources(terraform_modules_dir, binary_name)
+            for config in self._methods.values()
+        ]
+
+
+# Global default registry
+_default_registry = TerraformRegistry("global")
+
+
+def data_source(
+    key: str | None = None,
+    module_class: str | None = None,
+    **kwargs: Any,
+) -> Callable[[F], F]:
+    """Register a method as a Terraform data source on the global registry.
+
+    Args:
+        key: Output key name.
+        module_class: Module class prefix.
+        **kwargs: Additional options.
+
+    Returns:
+        Decorator function.
+    """
+    return _default_registry.data_source(key=key, module_class=module_class, **kwargs)
+
+
+def null_resource(
+    module_class: str | None = None,
+    **kwargs: Any,
+) -> Callable[[F], F]:
+    """Register a method as a Terraform null_resource on the global registry.
+
+    Args:
+        module_class: Module class prefix.
+        **kwargs: Additional options.
+
+    Returns:
+        Decorator function.
+    """
+    return _default_registry.null_resource(module_class=module_class, **kwargs)
+
+
+def get_global_registry() -> TerraformRegistry:
+    """Get the global default registry.
+
+    Returns:
+        The global TerraformRegistry instance.
+    """
+    return _default_registry

--- a/packages/python-terraform-bridge/src/python_terraform_bridge/runtime.py
+++ b/packages/python-terraform-bridge/src/python_terraform_bridge/runtime.py
@@ -1,0 +1,315 @@
+"""Terraform external data provider runtime.
+
+This module provides the runtime that receives requests from Terraform
+via stdin/environment and returns results via stdout.
+
+The runtime can be invoked either by:
+1. Running `python -m python_terraform_bridge <method_name>`
+2. Using the `terraform-bridge` CLI
+3. Programmatically via TerraformRuntime.invoke()
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+from directed_inputs_class import DirectedInputsClass  # noqa: TC002 - needed at runtime
+from extended_data_types import get_available_methods
+from lifecyclelogging import Logging
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TerraformRuntime:
+    """Runtime for executing Terraform data source methods.
+
+    This class handles:
+    1. Reading input from Terraform (stdin JSON or environment variables)
+    2. Invoking the appropriate method
+    3. Returning results in Terraform-compatible format (JSON with base64 encoding)
+
+    Example:
+        class MyDataSource(DirectedInputsClass):
+            def list_users(self, domain: str = None) -> dict:
+                return {"user1": {...}}
+
+        runtime = TerraformRuntime(MyDataSource)
+        runtime.run()  # Handle stdin/stdout
+    """
+
+    def __init__(
+        self,
+        data_source_class: type[DirectedInputsClass],
+        null_resource_class: type[DirectedInputsClass] | None = None,
+        logging: Logging | None = None,
+    ) -> None:
+        """Initialize the runtime.
+
+        Args:
+            data_source_class: Class containing data source methods.
+            null_resource_class: Optional class for null resource methods.
+            logging: Optional logging configuration.
+        """
+        self.data_source_class = data_source_class
+        self.null_resource_class = null_resource_class
+        self.logging = logging or Logging(
+            enable_console=False,
+            enable_file=True,
+            logger_name="terraform_bridge",
+        )
+        self.logger = self.logging.logger
+
+        # Build method registry
+        self._data_source_methods = get_available_methods(data_source_class)
+        self._null_resource_methods = (
+            get_available_methods(null_resource_class) if null_resource_class else {}
+        )
+
+    def get_available_methods(self) -> dict[str, str]:
+        """Get all available method names and descriptions.
+
+        Returns:
+            Dict mapping method names to docstrings.
+        """
+        methods = {}
+        methods.update(self._data_source_methods)
+        methods.update(self._null_resource_methods)
+        return methods
+
+    def invoke(
+        self,
+        method_name: str,
+        from_stdin: bool = True,
+        to_stdout: bool = True,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke a method by name.
+
+        Args:
+            method_name: Name of the method to invoke.
+            from_stdin: Read additional args from stdin.
+            to_stdout: Write result to stdout.
+            **kwargs: Method arguments.
+
+        Returns:
+            Method result.
+        """
+        if method_name in self._data_source_methods:
+            instance = self.data_source_class(
+                to_console=not to_stdout,
+                to_file=True,
+                from_stdin=from_stdin,
+                logging=self.logging,
+            )
+        elif method_name in self._null_resource_methods and self.null_resource_class:
+            instance = self.null_resource_class(
+                to_console=True,
+                to_file=True,
+                logging=self.logging,
+            )
+        else:
+            available = list(self._data_source_methods.keys()) + list(
+                self._null_resource_methods.keys()
+            )
+            raise ValueError(f"Unknown method: {method_name}. Available: {available}")
+
+        method = getattr(instance, method_name, None)
+        if method is None:
+            raise AttributeError(f"Method {method_name} not found on {instance}")
+
+        # Invoke the method
+        result = method(**kwargs)
+
+        if to_stdout:
+            self._output_result(result, method_name)
+
+        return result
+
+    def _output_result(self, result: Any, method_name: str) -> None:
+        """Format and output result to stdout for Terraform.
+
+        Terraform external data requires string values, so we base64 encode
+        complex data structures.
+
+        Args:
+            result: Method result to output.
+            method_name: Name of the method (used as output key).
+        """
+        if isinstance(result, dict) and all(isinstance(v, str) for v in result.values()):
+            # Already a string dict, output directly
+            output = result
+        else:
+            # Encode as base64 JSON
+            encoded = base64.b64encode(json.dumps(result, default=str).encode()).decode()
+            output = {method_name: encoded}
+
+        print(json.dumps(output))
+
+    def run(self, args: list[str] | None = None) -> None:
+        """Run the runtime as a CLI.
+
+        Args:
+            args: Command line arguments (defaults to sys.argv).
+        """
+        if args is None:
+            args = sys.argv[1:]
+
+        if not args:
+            self._print_help()
+            sys.exit(1)
+
+        method_name = "_".join(args)
+
+        if method_name == "show_methods":
+            methods = {
+                "data_sources": list(self._data_source_methods.keys()),
+                "resources": list(self._null_resource_methods.keys()),
+            }
+            print(json.dumps(methods, indent=2))
+            sys.exit(0)
+
+        if method_name not in self.get_available_methods():
+            self.logger.error(f"Unknown method: {method_name}")
+            self._print_help()
+            sys.exit(1)
+
+        try:
+            self.invoke(method_name, from_stdin=True, to_stdout=True)
+        except Exception as e:
+            self.logger.error(f"Method {method_name} failed: {e}", exc_info=True)
+            # Output error in Terraform-compatible format
+            print(json.dumps({"error": str(e)}))
+            sys.exit(1)
+
+    def _print_help(self) -> None:
+        """Print help message."""
+        help_txt = "Terraform Bridge Runtime\n\n"
+        help_txt += "Usage: python -m python_terraform_bridge <method_name>\n\n"
+
+        help_txt += "Data Sources:\n"
+        for name, docs in self._data_source_methods.items():
+            if name.startswith("_") or (docs and "NOPARSE" in docs):
+                continue
+            desc = docs.splitlines()[0] if docs else ""
+            help_txt += f"  {name}: {desc}\n"
+
+        if self._null_resource_methods:
+            help_txt += "\nNull Resources:\n"
+            for name, docs in self._null_resource_methods.items():
+                if name.startswith("_"):
+                    continue
+                desc = docs.splitlines()[0] if docs else ""
+                help_txt += f"  {name}: {desc}\n"
+
+        print(help_txt)
+
+
+def invoke_method_with_kwargs(
+    data_source_class: type[DirectedInputsClass],
+    method_name: str,
+    null_resource_class: type[DirectedInputsClass] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Invoke a method with explicit kwargs (for Lambda/programmatic use).
+
+    Args:
+        data_source_class: Class containing data source methods.
+        method_name: Name of the method to invoke.
+        null_resource_class: Optional class for null resources.
+        **kwargs: Method arguments.
+
+    Returns:
+        Method result.
+    """
+    runtime = TerraformRuntime(
+        data_source_class=data_source_class,
+        null_resource_class=null_resource_class,
+    )
+
+    return runtime.invoke(
+        method_name,
+        from_stdin=False,
+        to_stdout=False,
+        **kwargs,
+    )
+
+
+def lambda_handler_factory(
+    data_source_class: type[DirectedInputsClass],
+    null_resource_class: type[DirectedInputsClass] | None = None,
+) -> Callable[[dict[str, Any], Any], dict[str, Any]]:
+    """Create an AWS Lambda handler for Terraform bridge methods.
+
+    Args:
+        data_source_class: Class containing data source methods.
+        null_resource_class: Optional class for null resources.
+
+    Returns:
+        Lambda handler function.
+
+    Example:
+        from my_service import MyDataSource
+
+        handler = lambda_handler_factory(MyDataSource)
+
+        # In Lambda:
+        # {
+        #   "method": "list_users",
+        #   "kwargs": {"domain": "example.com"}
+        # }
+    """
+    runtime = TerraformRuntime(
+        data_source_class=data_source_class,
+        null_resource_class=null_resource_class,
+    )
+
+    def handler(event: dict[str, Any], context: Any = None) -> dict[str, Any]:
+        logging = Logging(
+            enable_console=True,
+            enable_file=False,
+            logger_name="lambda_handler",
+        )
+        logger = logging.logger
+
+        logger.info(f"Lambda invoked with event: {json.dumps(event, default=str)}")
+
+        try:
+            method_name = event.get("method")
+            if not method_name:
+                return {
+                    "statusCode": 400,
+                    "body": json.dumps(
+                        {
+                            "error": "No method specified",
+                            "available": list(runtime.get_available_methods().keys()),
+                        }
+                    ),
+                }
+
+            kwargs = event.get("kwargs", {})
+            logger.info(f"Invoking {method_name} with kwargs: {kwargs}")
+
+            result = runtime.invoke(
+                method_name,
+                from_stdin=False,
+                to_stdout=False,
+                **kwargs,
+            )
+
+            return {
+                "statusCode": 200,
+                "body": json.dumps(result, default=str) if not isinstance(result, str) else result,
+            }
+
+        except Exception as e:
+            logger.error(f"Lambda execution failed: {e}", exc_info=True)
+            return {
+                "statusCode": 500,
+                "body": json.dumps({"error": str(e), "type": type(e).__name__}),
+            }
+
+    return handler

--- a/packages/python-terraform-bridge/tests/__init__.py
+++ b/packages/python-terraform-bridge/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for python-terraform-bridge."""

--- a/packages/python-terraform-bridge/tests/test_module_resources.py
+++ b/packages/python-terraform-bridge/tests/test_module_resources.py
@@ -1,0 +1,370 @@
+"""Tests for TerraformModuleResources."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from python_terraform_bridge.module_resources import TerraformModuleResources
+
+
+class TestTerraformModuleResources:
+    """Tests for TerraformModuleResources class."""
+
+    def test_basic_data_source(self) -> None:
+        """Test basic data source module generation."""
+        docstring = """List all users.
+
+        generator=key: users, type: data_source
+
+        name: domain, required: false, type: string
+        """
+
+        resources = TerraformModuleResources(
+            module_name="list_users",
+            docstring=docstring,
+        )
+
+        assert resources.module_name == "list_users"
+        assert resources.descriptor == "List all users."
+        assert not resources.generation_forbidden
+
+    def test_generator_parameters_parsing(self) -> None:
+        """Test parsing of generator parameters."""
+        docstring = """Get data.
+
+        generator=key: output, type: data_source, module_class: myservice, plaintext_output: true
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_data",
+            docstring=docstring,
+        )
+
+        assert resources.generator_parameters["key"] == "output"
+        assert resources.generator_parameters["type"] == "data_source"
+        assert resources.generator_parameters["module_class"] == "myservice"
+        assert resources.generator_parameters["plaintext_output"] is True
+
+    def test_parameter_parsing(self) -> None:
+        """Test parsing of parameter definitions."""
+        docstring = """Get users.
+
+        generator=key: users
+
+        name: domain, required: true, type: string, description: "Target domain"
+        name: limit, required: false, type: number, default: 100
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_users",
+            docstring=docstring,
+        )
+
+        # Should have domain, limit, and checksum (auto-added)
+        param_names = {p.name for p in resources.module_parameters}
+        assert "domain" in param_names
+        assert "limit" in param_names
+        assert "checksum" in param_names
+
+    def test_noterraform_comment(self) -> None:
+        """Test that #NOTERRAFORM disables generation."""
+        docstring = """Internal method.
+
+        # NOTERRAFORM
+        """
+
+        resources = TerraformModuleResources(
+            module_name="internal_method",
+            docstring=docstring,
+        )
+
+        assert resources.generation_forbidden is True
+
+    def test_env_variable_parsing(self) -> None:
+        """Test parsing of environment variables."""
+        docstring = """Get data.
+
+        generator=key: data
+
+        env=name: GITHUB_TOKEN, required: true
+        env=name: API_SECRET, required: true, sensitive: true
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_data",
+            docstring=docstring,
+        )
+
+        assert "GITHUB_TOKEN" in resources.env_variables
+        assert "API_SECRET" in resources.sensitive_env_variables
+
+    def test_get_external_data(self) -> None:
+        """Test external_data module generation."""
+        docstring = """List users.
+
+        generator=key: users
+
+        name: domain, required: false, type: string
+        """
+
+        resources = TerraformModuleResources(
+            module_name="list_users",
+            docstring=docstring,
+        )
+
+        module_json = resources.get_external_data()
+
+        # Check structure
+        assert "terraform" in module_json
+        assert "variable" in module_json
+        assert "data" in module_json
+        assert "locals" in module_json
+        assert "output" in module_json
+
+        # Check terraform block
+        assert "required_providers" in module_json["terraform"]
+        assert "external" in module_json["terraform"]["required_providers"]
+
+        # Check data block
+        assert "external" in module_json["data"]
+        assert "default" in module_json["data"]["external"]
+
+        # Check output
+        assert "users" in module_json["output"]
+
+    def test_get_null_resource(self) -> None:
+        """Test null_resource module generation."""
+        docstring = """Update something.
+
+        generator=type: null_resource
+
+        name: target, required: true, type: string
+        """
+
+        resources = TerraformModuleResources(
+            module_name="update_target",
+            docstring=docstring,
+        )
+
+        module_json = resources.get_null_resource()
+
+        # Check structure
+        assert "terraform" in module_json
+        assert "variable" in module_json
+        assert "resource" in module_json
+
+        # Check resource block
+        assert "terraform_data" in module_json["resource"]
+        assert "default" in module_json["resource"]["terraform_data"]
+
+        # Check provisioner
+        resource = module_json["resource"]["terraform_data"]["default"]
+        assert "triggers_replace" in resource
+        assert "provisioner" in resource
+
+    def test_get_mixed_data_source(self) -> None:
+        """Test get_mixed for data_source type."""
+        docstring = """List items.
+
+        generator=key: items, type: data_source
+        """
+
+        resources = TerraformModuleResources(
+            module_name="list_items",
+            docstring=docstring,
+        )
+
+        module_json = resources.get_mixed()
+
+        # Should be external data format
+        assert "data" in module_json
+        assert "external" in module_json["data"]
+
+    def test_get_mixed_null_resource(self) -> None:
+        """Test get_mixed for null_resource type."""
+        docstring = """Create item.
+
+        generator=type: null_resource
+        """
+
+        resources = TerraformModuleResources(
+            module_name="create_item",
+            docstring=docstring,
+        )
+
+        module_json = resources.get_mixed()
+
+        # Should be terraform_data format
+        assert "resource" in module_json
+        assert "terraform_data" in module_json["resource"]
+
+    def test_get_module_path(self) -> None:
+        """Test module path generation."""
+        docstring = """Get data.
+
+        generator=key: data, module_class: aws
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_data",
+            docstring=docstring,
+            terraform_modules_dir="modules",
+        )
+
+        path = resources.get_module_path()
+
+        assert isinstance(path, Path)
+        assert "aws" in str(path)
+        assert "get-data" in str(path) or "get_data" in str(path)
+        assert path.name == "main.tf.json"
+
+    def test_get_module_name(self) -> None:
+        """Test module name generation."""
+        resources = TerraformModuleResources(
+            module_name="list_users",
+            docstring="Test.\n\ngenerator=key: users, module_class: github",
+        )
+
+        name = resources.get_module_name()
+
+        # Should combine class and name with delimiter
+        assert "github" in name
+        assert "list" in name
+        assert "users" in name
+
+    def test_plaintext_output(self) -> None:
+        """Test plaintext output mode."""
+        docstring = """Get status.
+
+        generator=key: status, plaintext_output: true
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_status",
+            docstring=docstring,
+        )
+
+        module_json = resources.get_external_data()
+
+        # Plaintext output should not use jsondecode/base64decode
+        locals_block = module_json["locals"]
+        results = locals_block["results"]
+        assert "jsondecode" not in results
+        assert "base64decode" not in results
+
+    def test_always_run(self) -> None:
+        """Test always run trigger."""
+        docstring = """Get timestamp.
+
+        generator=key: time, always: true
+
+        name: zone, required: false, type: string
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_timestamp",
+            docstring=docstring,
+        )
+
+        triggers = resources.get_triggers()
+
+        assert "always" in triggers
+        assert "timestamp()" in triggers["always"]
+
+    def test_extra_outputs(self) -> None:
+        """Test extra output definitions."""
+        docstring = """Get data with multiple outputs.
+
+        generator=key: primary
+
+        extra_output=key: secondary
+        extra_output=key: tertiary
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_multi",
+            docstring=docstring,
+        )
+
+        module_json = resources.get_external_data()
+
+        # Should have all outputs
+        assert "primary" in module_json["output"]
+        assert "secondary" in module_json["output"]
+        assert "tertiary" in module_json["output"]
+
+    def test_required_providers(self) -> None:
+        """Test required provider definitions.
+
+        Note: Values containing special characters like / must be quoted.
+        """
+        docstring = """Get from AWS.
+
+        generator=key: data
+
+        required_provider=name: aws, source: "hashicorp/aws", version: ">=5.0"
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_aws_data",
+            docstring=docstring,
+        )
+
+        module_json = resources.get_external_data()
+
+        providers = module_json["terraform"]["required_providers"]
+        assert "aws" in providers
+        assert providers["aws"]["source"] == "hashicorp/aws"
+
+    def test_binary_name_customization(self) -> None:
+        """Test custom binary name."""
+        resources = TerraformModuleResources(
+            module_name="test",
+            docstring="Test.\n\ngenerator=key: test",
+            binary_name="terraform-modules",
+        )
+
+        assert resources.binary_name == "terraform-modules"
+        assert resources.call == "terraform-modules test"
+
+    def test_empty_docstring(self) -> None:
+        """Test handling of empty docstring."""
+        resources = TerraformModuleResources(
+            module_name="no_docs",
+            docstring=None,
+        )
+
+        # Should not raise, just have minimal config
+        assert resources.module_name == "no_docs"
+        assert resources.descriptor is None
+
+    def test_get_variables(self) -> None:
+        """Test variable block generation."""
+        docstring = """Get data.
+
+        generator=key: data
+
+        name: required_param, required: true, type: string
+        name: optional_param, required: false, type: string, default: "test"
+        name: sensitive_param, required: true, type: string, sensitive: true
+        """
+
+        resources = TerraformModuleResources(
+            module_name="get_data",
+            docstring=docstring,
+        )
+
+        variables = resources.get_variables()
+
+        assert "required_param" in variables
+        assert "optional_param" in variables
+        assert "sensitive_param" in variables
+
+        # Check required has no default
+        assert "default" not in variables["required_param"]
+
+        # Check optional has default
+        assert variables["optional_param"]["default"] == "test"
+
+        # Check sensitive flag
+        assert variables["sensitive_param"]["sensitive"] is True

--- a/packages/python-terraform-bridge/tests/test_parameter.py
+++ b/packages/python-terraform-bridge/tests/test_parameter.py
@@ -1,0 +1,167 @@
+"""Tests for TerraformModuleParameter."""
+
+from __future__ import annotations
+
+import inspect
+
+from python_terraform_bridge.parameter import TerraformModuleParameter
+
+
+class TestTerraformModuleParameter:
+    """Tests for TerraformModuleParameter class."""
+
+    def test_basic_string_parameter(self) -> None:
+        """Test basic string parameter creation."""
+        param = TerraformModuleParameter(name="domain")
+        assert param.name == "domain"
+        assert param.type == "any"  # No default, no *_id suffix -> any
+        assert param.required is True
+
+    def test_string_type_inference(self) -> None:
+        """Test type inference from string default."""
+        param = TerraformModuleParameter(name="value", default="test")
+        assert param.type == "string"
+
+    def test_bool_type_inference(self) -> None:
+        """Test type inference from bool default."""
+        param = TerraformModuleParameter(name="enabled", default=False)
+        assert param.type == "bool"
+
+    def test_number_type_inference(self) -> None:
+        """Test type inference from int default."""
+        param = TerraformModuleParameter(name="count", default=10)
+        assert param.type == "number"
+
+    def test_id_suffix_infers_string(self) -> None:
+        """Test that *_id suffix infers string type."""
+        param = TerraformModuleParameter(name="user_id")
+        assert param.type == "string"
+
+    def test_get_variable_required(self) -> None:
+        """Test get_variable for required parameter."""
+        param = TerraformModuleParameter(
+            name="domain",
+            required=True,
+            type="string",  # Explicit type to test variable generation
+            description="Target domain",
+        )
+        var = param.get_variable()
+
+        assert var["type"] == "string"
+        assert "default" not in var
+        assert var["description"] == "Target domain"
+
+    def test_get_variable_optional(self) -> None:
+        """Test get_variable for optional parameter."""
+        param = TerraformModuleParameter(
+            name="limit",
+            required=False,
+            default=100,
+            type="number",
+        )
+        var = param.get_variable()
+
+        assert var["type"] == "number"
+        assert var["default"] == 100
+
+    def test_get_variable_sensitive(self) -> None:
+        """Test get_variable for sensitive parameter."""
+        param = TerraformModuleParameter(
+            name="api_key",
+            sensitive=True,
+        )
+        var = param.get_variable()
+
+        assert var["sensitive"] is True
+
+    def test_get_trigger_basic(self) -> None:
+        """Test basic trigger generation."""
+        param = TerraformModuleParameter(name="domain")
+        trigger = param.get_trigger()
+
+        assert trigger == "${try(nonsensitive(var.domain), var.domain)}"
+
+    def test_get_trigger_json_encode(self) -> None:
+        """Test trigger with JSON encoding."""
+        param = TerraformModuleParameter(name="config", json_encode=True)
+        trigger = param.get_trigger()
+
+        assert "jsonencode" in trigger
+        assert trigger == "${try(nonsensitive(jsonencode(var.config)), jsonencode(var.config))}"
+
+    def test_get_trigger_base64_encode(self) -> None:
+        """Test trigger with base64 encoding."""
+        param = TerraformModuleParameter(name="data", base64_encode=True)
+        trigger = param.get_trigger()
+
+        assert "base64encode" in trigger
+
+    def test_get_trigger_both_encodings(self) -> None:
+        """Test trigger with both encodings."""
+        param = TerraformModuleParameter(name="data", json_encode=True, base64_encode=True)
+        trigger = param.get_trigger()
+
+        # Both should be applied
+        assert "jsonencode" in trigger
+        assert "base64encode" in trigger
+
+    def test_get_trigger_disable_encoding(self) -> None:
+        """Test trigger with encoding disabled."""
+        param = TerraformModuleParameter(name="data", json_encode=True)
+        trigger = param.get_trigger(disable_encoding=True)
+
+        assert "jsonencode" not in trigger
+
+    def test_get_trigger_custom(self) -> None:
+        """Test custom trigger override."""
+        param = TerraformModuleParameter(name="data", trigger="${each.key}")
+        trigger = param.get_trigger()
+
+        assert trigger == "${each.key}"
+
+    def test_from_type_hint_string(self) -> None:
+        """Test parameter from string type hint."""
+        param = TerraformModuleParameter.from_type_hint(
+            name="domain",
+            type_hint=str,
+            default=inspect.Parameter.empty,
+        )
+
+        assert param.name == "domain"
+        assert param.type == "string"
+        assert param.required is True
+
+    def test_from_type_hint_optional(self) -> None:
+        """Test parameter from optional with default."""
+        param = TerraformModuleParameter.from_type_hint(
+            name="limit",
+            type_hint=int,
+            default=100,
+        )
+
+        assert param.required is False
+        assert param.default == 100
+        assert param.type == "number"
+
+    def test_from_type_hint_dict(self) -> None:
+        """Test parameter from dict type hint."""
+        param = TerraformModuleParameter.from_type_hint(
+            name="config",
+            type_hint=dict,
+            default=inspect.Parameter.empty,
+        )
+
+        assert param.type == "map(any)"
+        assert param.json_encode is True
+        assert param.base64_encode is True
+
+    def test_from_type_hint_list(self) -> None:
+        """Test parameter from list type hint."""
+        param = TerraformModuleParameter.from_type_hint(
+            name="items",
+            type_hint=list,
+            default=[],
+        )
+
+        assert param.type == "list(any)"
+        assert param.required is False

--- a/packages/python-terraform-bridge/tests/test_registry.py
+++ b/packages/python-terraform-bridge/tests/test_registry.py
@@ -1,0 +1,267 @@
+"""Tests for TerraformRegistry."""
+
+from __future__ import annotations
+
+import tempfile
+
+from python_terraform_bridge.registry import TerraformMethodConfig, TerraformRegistry
+
+
+class TestTerraformMethodConfig:
+    """Tests for TerraformMethodConfig."""
+
+    def test_description_from_docstring(self) -> None:
+        """Test description extraction from docstring."""
+
+        def my_method() -> dict:
+            """This is the description.
+
+            More details here.
+            """
+            return {}
+
+        config = TerraformMethodConfig(
+            method=my_method,
+            method_name="my_method",
+        )
+
+        assert config.description == "This is the description."
+
+    def test_key_defaults_to_method_name(self) -> None:
+        """Test that key defaults to method name."""
+
+        def list_users() -> dict:
+            """List users."""
+            return {}
+
+        config = TerraformMethodConfig(
+            method=list_users,
+            method_name="list_users",
+        )
+
+        assert config.key == "list_users"
+
+    def test_explicit_key(self) -> None:
+        """Test explicit key override."""
+
+        def list_users() -> dict:
+            """List users."""
+            return {}
+
+        config = TerraformMethodConfig(
+            method=list_users,
+            method_name="list_users",
+            key="users",
+        )
+
+        assert config.key == "users"
+
+
+class TestTerraformRegistry:
+    """Tests for TerraformRegistry."""
+
+    def test_register_basic(self) -> None:
+        """Test basic method registration."""
+        registry = TerraformRegistry()
+
+        @registry.register(key="users")
+        def list_users() -> dict:
+            """List all users."""
+            return {}
+
+        assert "list_users" in registry._methods
+        assert registry._methods["list_users"].key == "users"
+
+    def test_data_source_decorator(self) -> None:
+        """Test data_source decorator."""
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="users", module_class="github")
+        def list_users(domain: str | None = None) -> dict:
+            """List GitHub users."""
+            return {}
+
+        config = registry.get_method("list_users")
+        assert config is not None
+        assert config.module_type == "data_source"
+        assert config.module_class == "github"
+        assert config.key == "users"
+
+    def test_null_resource_decorator(self) -> None:
+        """Test null_resource decorator."""
+        registry = TerraformRegistry()
+
+        @registry.null_resource(module_class="aws")
+        def create_bucket(name: str) -> None:
+            """Create S3 bucket."""
+            pass
+
+        config = registry.get_method("create_bucket")
+        assert config is not None
+        assert config.module_type == "null_resource"
+        assert config.module_class == "aws"
+
+    def test_parameter_inference(self) -> None:
+        """Test automatic parameter inference."""
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="data")
+        def get_data(
+            required_str: str,
+            optional_str: str = "default",
+            number_param: int = 10,
+        ) -> dict:
+            """Get data."""
+            return {}
+
+        config = registry.get_method("get_data")
+        assert config is not None
+
+        param_names = {p.name for p in config.parameters}
+        assert "required_str" in param_names
+        assert "optional_str" in param_names
+        assert "number_param" in param_names
+
+        # Check required/optional
+        for param in config.parameters:
+            if param.name == "required_str":
+                assert param.required is True
+            elif param.name == "optional_str":
+                assert param.required is False
+                assert param.default == "default"
+
+    def test_list_methods(self) -> None:
+        """Test listing registered methods."""
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="users")
+        def list_users() -> dict:
+            """List all users."""
+            return {}
+
+        @registry.data_source(key="groups")
+        def list_groups() -> dict:
+            """List all groups."""
+            return {}
+
+        methods = registry.list_methods()
+
+        assert "list_users" in methods
+        assert "list_groups" in methods
+        assert methods["list_users"] == "List all users."
+        assert methods["list_groups"] == "List all groups."
+
+    def test_generate_modules(self) -> None:
+        """Test module generation."""
+        import json
+
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="users", module_class="github")
+        def list_users(org: str | None = None) -> dict:
+            """List GitHub users."""
+            return {}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generated = registry.generate_modules(output_dir=tmpdir)
+
+            assert "list_users" in generated
+            assert generated["list_users"].exists()
+
+            # Check JSON content
+            with generated["list_users"].open() as f:
+                module_json = json.load(f)
+
+            assert "terraform" in module_json
+            assert "variable" in module_json
+            assert "data" in module_json
+
+    def test_generation_forbidden(self) -> None:
+        """Test that generation_forbidden methods are skipped."""
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="users", generation_forbidden=True)
+        def internal_users() -> dict:
+            """Internal method."""
+            return {}
+
+        @registry.data_source(key="groups")
+        def list_groups() -> dict:
+            """List groups."""
+            return {}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generated = registry.generate_modules(output_dir=tmpdir)
+
+            assert "internal_users" not in generated
+            assert "list_groups" in generated
+
+    def test_to_module_resources(self) -> None:
+        """Test conversion to TerraformModuleResources."""
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="users", module_class="github")
+        def list_users(domain: str | None = None) -> dict:
+            """List GitHub users."""
+            return {}
+
+        config = registry.get_method("list_users")
+        assert config is not None
+
+        resources = config.to_module_resources()
+
+        assert resources.module_name == "list_users"
+        assert resources.generator_parameters["key"] == "users"
+
+    def test_wrapper_preserves_function(self) -> None:
+        """Test that decorated function still works."""
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="result")
+        def add_numbers(a: int = 0, b: int = 0) -> dict:
+            """Add two numbers."""
+            return {"sum": a + b}
+
+        result = add_numbers(a=5, b=3)
+        assert result == {"sum": 8}
+
+    def test_multiple_registries(self) -> None:
+        """Test multiple independent registries."""
+        registry1 = TerraformRegistry("registry1")
+        registry2 = TerraformRegistry("registry2")
+
+        @registry1.data_source(key="data1")
+        def method1() -> dict:
+            """Method 1."""
+            return {}
+
+        @registry2.data_source(key="data2")
+        def method2() -> dict:
+            """Method 2."""
+            return {}
+
+        assert "method1" in registry1._methods
+        assert "method1" not in registry2._methods
+        assert "method2" in registry2._methods
+        assert "method2" not in registry1._methods
+
+    def test_get_all_resources(self) -> None:
+        """Test getting all resources."""
+        registry = TerraformRegistry()
+
+        @registry.data_source(key="users")
+        def list_users() -> dict:
+            """List users."""
+            return {}
+
+        @registry.data_source(key="groups")
+        def list_groups() -> dict:
+            """List groups."""
+            return {}
+
+        resources = registry.get_all_resources()
+
+        assert len(resources) == 2
+        names = {r.module_name for r in resources}
+        assert "list_users" in names
+        assert "list_groups" in names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ members = [
     "packages/lifecyclelogging",
     "packages/directed-inputs-class",
     "packages/vendor-connectors",
+    "packages/python-terraform-bridge",
 ]
 
 [tool.uv.sources]
@@ -17,6 +18,7 @@ extended-data-types = { workspace = true }
 lifecyclelogging = { workspace = true }
 directed-inputs-class = { workspace = true }
 vendor-connectors = { workspace = true }
+python-terraform-bridge = { workspace = true }
 
 [project]
 name = "jbcom-control-center"
@@ -145,6 +147,15 @@ ignore = [
     "S",      # Skip security checks for credential handling patterns
     "B008",   # Function calls in defaults
     "C901",   # Complexity
+]
+# python-terraform-bridge: Python 3.10+, CLI needs print, subprocess for terraform
+"packages/python-terraform-bridge/**/*.py" = [
+    "D",      # Skip docstring requirements during development
+    "T201",   # Print statements required for CLI output
+    "EM101", "EM102",  # Exception message style - match terraform-modules patterns
+]
+"packages/python-terraform-bridge/tests/**/*.py" = [
+    "D103", "S101", "D100", "D104",  # Tests: skip docstrings, use asserts
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "extended-data-types",
     "jbcom-control-center",
     "lifecyclelogging",
+    "python-terraform-bridge",
     "vendor-connectors",
 ]
 
@@ -2736,6 +2737,41 @@ wheels = [
 ]
 
 [[package]]
+name = "python-terraform-bridge"
+version = "202511.1.0"
+source = { editable = "packages/python-terraform-bridge" }
+dependencies = [
+    { name = "directed-inputs-class" },
+    { name = "extended-data-types" },
+    { name = "lifecyclelogging" },
+    { name = "tssplit" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "directed-inputs-class", editable = "packages/directed-inputs-class" },
+    { name = "extended-data-types", editable = "packages/extended-data-types" },
+    { name = "lifecyclelogging", editable = "packages/lifecyclelogging" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
+    { name = "python-terraform-bridge", extras = ["test"], marker = "extra == 'dev'", editable = "packages/python-terraform-bridge" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "tssplit", specifier = ">=0.1.1" },
+]
+provides-extras = ["test", "dev"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3385,6 +3421,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tssplit"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/ea/ce705a18347a87a7a22dba4f0dd100ba1cc6fca0b3ad4b0613461bfcc90b/tssplit-1.0.9.tar.gz", hash = "sha256:8e58973e1d69c21fd9b4deeaa757fb6ab8f17b4fa7469387a120f0e99bde8e22", size = 3570, upload-time = "2024-12-25T17:31:59.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/d1/6b624a6e44a299427615dee45fbb19e2f8d3babeaaac78635d2eca4e7370/tssplit-1.0.9-py3-none-any.whl", hash = "sha256:4f23f0cb3c7a27c7ed8bb2b3e7ca06606ee268044fc78a20419b9673beb85683", size = 4234, upload-time = "2024-12-25T17:31:57.572Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 source = { registry = "https://pypi.org/simple" }
@@ -3455,7 +3500,7 @@ wheels = [
 
 [[package]]
 name = "vendor-connectors"
-version = "202511.8.0"
+version = "202511.9.0"
 source = { editable = "packages/vendor-connectors" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

New OSS package for Terraform ↔ Python bridging with decorator-based method registration. Extracts and generalizes the Terraform module generation code from terraform-modules.

### Key Features
- `@registry.data_source()` decorator for external data sources
- `@registry.null_resource()` decorator for null resources
- Automatic parameter inference from type hints
- Docstring-based configuration (legacy support)
- Module generation to Terraform JSON
- CLI tool: `terraform-bridge generate/list/run`

### Components
| Component | Purpose |
|-----------|---------|
| `TerraformModuleParameter` | Type-inferred Terraform variable definitions |
| `TerraformModuleResources` | Module generation from Python methods |
| `TerraformRegistry` | Decorator-based method registration |
| `runtime.py` | External data provider runtime |
| `cli.py` | CLI interface |

### Usage Example
```python
from python_terraform_bridge import TerraformRegistry

registry = TerraformRegistry()

@registry.data_source(key="users", module_class="github")
def list_users(org: str | None = None) -> dict:
    return {...}

registry.generate_modules("./terraform-modules")
```

## Test Plan

- [x] 50 tests passing
- [x] Lint checks pass

```bash
cd packages/python-terraform-bridge && uv run pytest tests/ -v --override-ini="addopts="
uv run ruff check packages/python-terraform-bridge
```

## Dependencies

- **Depends on**: 
  - #246 (docs/wiki-orchestration-update) - merge first
  - #247 (feat/directed-inputs-decorator-api) - merge before integration
- **Blocks**: vendor-connectors migration PR

## Handoff Context

📚 **Documentation**: `.cursor/agents/terraform-modules-migration/ORCHESTRATION.md`

### For @cursor

After this PR merges:
1. Create branch `feat/vendor-connectors-migration` from `main`
2. Add the vendor-connectors migration functions (see MIGRATION_STATUS.md)
3. Files needed:
   - `packages/vendor-connectors/src/vendor_connectors/aws/s3.py`
   - `packages/vendor-connectors/src/vendor_connectors/github/__init__.py`
   - `packages/vendor-connectors/src/vendor_connectors/google/billing.py`
   - `packages/vendor-connectors/src/vendor_connectors/google/services.py`
   - `packages/vendor-connectors/src/vendor_connectors/google/workspace.py`
4. Run existing connector tests
5. Update API_REFERENCE.md and MIGRATION_STATUS.md

See `PR_PLAN.md` for complete handoff protocol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `python-terraform-bridge` package with decorator-based registration, Terraform module generation, a runtime/CLI, and tests.
> 
> - **New package `packages/python-terraform-bridge`**:
>   - **Core APIs**: `TerraformRegistry` (decorator-based `data_source`/`null_resource`), `TerraformModuleResources` (generate Terraform JSON), `TerraformModuleParameter` (variable/trigger handling), `TerraformRuntime` (stdin/stdout external data provider) + Lambda handler.
>   - **CLI**: `terraform-bridge` (`generate`, `list`, `run`) and `python -m python_terraform_bridge` entrypoint.
>   - **Docs**: Comprehensive `README.md` (usage, docstring format, architecture).
>   - **Packaging**: `pyproject.toml`, `__init__` exports/version, `py.typed`, console script; added to workspace/tooling config.
>   - **Tests**: Unit tests for resources, parameters, registry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b3495cb24f29870633d9f32c58c6cdbdc94ff7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->