### PR TITLE
fix(fleet): correct API response parsing for list endpoints

### DIFF
--- a/packages/cursor-fleet/src/ai-analyzer.ts
+++ b/packages/cursor-fleet/src/ai-analyzer.ts
@@ -14,18 +14,19 @@ import { execSync } from "node:child_process";
 import type { Conversation, Message } from "./types.js";
 
 // Schemas for structured output
+// Note: Using .nullable().optional() to handle AI returning null instead of omitting fields
 const TaskAnalysisSchema = z.object({
   completedTasks: z.array(z.object({
     title: z.string(),
     description: z.string(),
     evidence: z.string(),
-    prNumber: z.number().optional(),
+    prNumber: z.number().nullable().optional(),
   })),
   outstandingTasks: z.array(z.object({
     title: z.string(),
     description: z.string(),
     priority: z.enum(["critical", "high", "medium", "low"]),
-    blockedBy: z.string().optional(),
+    blockedBy: z.string().nullable().optional(),
     suggestedLabels: z.array(z.string()),
   })),
   blockers: z.array(z.object({
@@ -36,7 +37,7 @@ const TaskAnalysisSchema = z.object({
   decisions: z.array(z.object({
     decision: z.string(),
     rationale: z.string(),
-    alternatives: z.array(z.string()).optional(),
+    alternatives: z.array(z.string()).nullable().optional(),
   })),
   summary: z.string(),
 });

--- a/packages/cursor-fleet/src/cursor-api.ts
+++ b/packages/cursor-fleet/src/cursor-api.ts
@@ -172,9 +172,14 @@ export class CursorAPI {
 
   /**
    * List all agents
+   * 
+   * The Cursor API returns { agents: Agent[], nextCursor?: string }
+   * but we normalize this to just return the agents array.
    */
   async listAgents(): Promise<FleetResult<Agent[]>> {
-    return this.request<Agent[]>("/agents");
+    const result = await this.request<{ agents: Agent[]; nextCursor?: string }>("/agents");
+    if (!result.success) return { success: false, error: result.error };
+    return { success: true, data: result.data?.agents ?? [] };
   }
 
   /**
@@ -230,8 +235,13 @@ export class CursorAPI {
 
   /**
    * List available repositories
+   * 
+   * The Cursor API returns { repositories: Repository[] }
+   * but we normalize this to just return the repositories array.
    */
   async listRepositories(): Promise<FleetResult<Repository[]>> {
-    return this.request<Repository[]>("/repositories");
+    const result = await this.request<{ repositories: Repository[] }>("/repositories");
+    if (!result.success) return { success: false, error: result.error };
+    return { success: true, data: result.data?.repositories ?? [] };
   }
 }


### PR DESCRIPTION
## Summary

Fixes critical bugs in cursor-fleet package that prevented `list` and `repos` commands from working.

## Bug Description

The Cursor API returns wrapped responses:
- `/agents` returns `{ agents: Agent[], nextCursor?: string }`  
- `/repositories` returns `{ repositories: Repository[] }`

But `CursorAPI.listAgents()` and `CursorAPI.listRepositories()` were expecting direct arrays, causing:
```
TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
```

## Fix

Extract the inner array from the wrapped response objects before returning.

## Additional Fix

Also fixes AI analyzer schema validation errors when Claude returns `null` instead of omitting optional fields. The schema now uses `.nullable().optional()` pattern to accept both.

## Testing

- [x] `cursor-fleet list` now works correctly
- [x] `cursor-fleet list --running` works correctly  
- [x] TypeScript compiles without errors
- [x] Self-identified as running agent bc-3248f18e

## Files Changed

- `packages/cursor-fleet/src/cursor-api.ts` - Fix list/repos response parsing
- `packages/cursor-fleet/src/ai-analyzer.ts` - Fix nullable schema fields

---
**Requesting QA AI review**: @gemini-code-assist @amazon-q-developer @cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes Cursor list endpoints to return arrays and updates analyzer schemas to accept nullable optional fields.
> 
> - **Cursor API (`packages/cursor-fleet/src/cursor-api.ts`)**:
>   - `listAgents()`: unwraps `{ agents, nextCursor? }` and returns `Agent[]`.
>   - `listRepositories()`: unwraps `{ repositories }` and returns `Repository[]`.
> - **AI Analyzer (`packages/cursor-fleet/src/ai-analyzer.ts`)**:
>   - Schema tweaks to accept nullable optionals: `completedTasks.prNumber`, `outstandingTasks.blockedBy`, `decisions.alternatives` use `.nullable().optional()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ffe6cdca461eb4a967f7f09502ba8be9b7f6bb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->