### PR TITLE
fix(ci): correct repo-file-sync-action version to v1.21.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
 
       - name: Sync to public repo
         if: steps.check.outputs.should_release == 'true'
-        uses: BetaHuhn/repo-file-sync-action@v1.22.0
+        uses: BetaHuhn/repo-file-sync-action@v1.21.1
         with:
           GH_PAT: ${{ secrets.CI_GITHUB_TOKEN }}
           CONFIG_PATH: .github/sync/${{ matrix.package }}.yml


### PR DESCRIPTION
## Summary
- Fixes release job failures caused by non-existent action version `BetaHuhn/repo-file-sync-action@v1.22.0`
- Updates to latest available version `v1.21.1`

## Root Cause
The action version `v1.22.0` doesn't exist. The error was:
```
Unable to resolve action `betahuhn/repo-file-sync-action@v1.22.0`, unable to find version `v1.22.0`
```

## Test plan
- [ ] CI passes with corrected action version
- [ ] Release jobs can reach "Sync to public repo" step

Fixes failure: https://github.com/jbcom/jbcom-control-center/actions/runs/19801230920

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the release workflow to use `BetaHuhn/repo-file-sync-action@v1.21.1` for the "Sync to public repo" step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 522449711bb8c37adbdc16f9855c7ce9fc02fd80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->