### PR TITLE
fix(ci): remove invalid --skip-existing flag from semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         run: |
           # Let PSR handle version bump, commit, tag, and push
-          semantic-release version --skip-existing
+          semantic-release version
 
       - name: Download built packages
         if: steps.check.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary
- Removes invalid `--skip-existing` flag from `semantic-release version` command
- This flag doesn't exist in python-semantic-release

## Root Cause
The CI was failing with:
```
Error: No such option: --skip-existing
```

The "Check if release needed" step already determines whether a release is needed, so this flag is unnecessary anyway.

## Test plan
- [ ] CI passes
- [ ] Release jobs complete successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the unsupported --skip-existing option from the semantic-release version step in the CI release workflow to fix release failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83cb338123b6d0f5ce07a157d5c1bd56170855f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->