### PR TITLE
fix: update default model to claude-4-opus for Cursor compatibility

### DIFF
--- a/agentic.config.json
+++ b/agentic.config.json
@@ -18,7 +18,7 @@
     "defaultTokenEnvVar": "GITHUB_TOKEN",
     "prReviewTokenEnvVar": "GITHUB_JBCOM_TOKEN"
   },
-  "defaultModel": "claude-sonnet-4-20250514",
+  "defaultModel": "claude-4-opus",
   "defaultRepository": "jbcom/jbcom-control-center",
   "logLevel": "info"
 }

--- a/packages/agentic-control/src/core/config.ts
+++ b/packages/agentic-control/src/core/config.ts
@@ -83,8 +83,8 @@ export interface AgenticConfig {
 // ============================================
 
 const DEFAULT_CONFIG: AgenticConfig = {
-  // AI model - uses Claude Sonnet as sensible default
-  defaultModel: "claude-sonnet-4-20250514",
+  // AI model - uses Claude 4 Opus as sensible default for Cursor
+  defaultModel: "claude-4-opus",
   logLevel: "info",
   verbose: false,
   // Cursor defaults


### PR DESCRIPTION
The Cursor Background Agent API doesn't accept 'claude-sonnet-4-20250514' as a model name. Updated to 'claude-4-opus' which works.

Part of #286

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the default model from `claude-sonnet-4-20250514` to `claude-4-opus` across config.
> 
> - **Config**:
>   - Update `defaultModel` to `claude-4-opus` in `agentic.config.json`.
>   - Update `DEFAULT_CONFIG.defaultModel` to `claude-4-opus` in `packages/agentic-control/src/core/config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5dcb4295246547e34689964bcc3f0a5f13c3d61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->