### PR TITLE
feat(ci): add agentic-control build, test, and npm release to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
-      - uses: actions/setup-node@3de7cc27f0d79dcc3bae9b2d5f17cd7b9f0e3ad8  # v4.4.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: "22"
 
@@ -173,7 +173,7 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
 
-      - uses: actions/setup-node@3de7cc27f0d79dcc3bae9b2d5f17cd7b9f0e3ad8  # v4.4.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: "22"
 
@@ -399,7 +399,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.CI_GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@3de7cc27f0d79dcc3bae9b2d5f17cd7b9f0e3ad8  # v4.4.0
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- Adds build job for agentic-control TypeScript compilation
- Adds test job for agentic-control vitest tests
- Adds npm release job with semantic versioning based on conventional commits
- Updates required-checks-pass to include agentic-control jobs

## Configuration Required
- **NPM_TOKEN** secret must be added to repository secrets for npm publish to work

## Related
Part of #286

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CI jobs to build and test `packages/agentic-control` and a main-branch npm release flow, and includes these jobs in required checks.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **Agentic-control (TypeScript/Node.js)**:
>     - New `agentic-control-build` job using Node 22 + pnpm with cache; builds `packages/agentic-control` and uploads `dist` artifact.
>     - New `agentic-control-test` job (depends on build); runs package tests with pnpm.
>   - **Release to npm (main only)**:
>     - New `release-npm` job to version, tag, publish `packages/agentic-control` to npm, and create a GitHub Release.
>     - Version bump determined from conventional commits since last `agentic-control-v*` tag; supports initial release when no tag exists.
>   - **Required checks**: `required-checks-pass` updated to include `agentic-control-build` and `agentic-control-test`.
>   - Minor: clarify lint section heading to "LINT (Python)".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cc9b982b1d90292326a6c98ab0661f9e77d43ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->