### PR TITLE
fix(agentic-control): read version from package.json at runtime

### DIFF
--- a/packages/agentic-control/src/index.ts
+++ b/packages/agentic-control/src/index.ts
@@ -30,5 +30,8 @@ export { GitHubClient, cloneRepo, isValidGitRef, isValidRepoFormat } from "./git
 // Handoff protocols
 export { HandoffManager, type TakeoverOptions } from "./handoff/index.js";
 
-// Version - managed by semantic-release
-export const VERSION = "0.0.0";
+// Version - read from package.json at runtime
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+export const VERSION = pkg.version;


### PR DESCRIPTION
Read VERSION from package.json at runtime instead of hardcoding.

This ensures semantic-release version bumps are reflected in CLI output.

Part of #286

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Read VERSION from package.json at runtime instead of a hardcoded constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba39bbf30e40fb2dfd243d734a53783a9c835461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->