### PR TITLE
fix(ci): use PYPI_TOKEN for Python packages instead of trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ concurrency:
   cancel-in-progress: true
 
 # Workflow-level permissions
-# Using Trusted Publishing for both PyPI and npm (OIDC)
+# PyPI uses PYPI_TOKEN, npm uses Trusted Publishing (OIDC)
 permissions:
   contents: read
   pull-requests: write
   pages: write
-  id-token: write  # Required for Trusted Publishing (PyPI + npm)
+  id-token: write  # Required for npm Trusted Publishing
 
 jobs:
   # ============================================
@@ -215,11 +215,10 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: required-checks-pass
     runs-on: ubuntu-latest
-    environment: pypi  # Required for PyPI Trusted Publishing OIDC
 
     permissions:
       contents: write
-      id-token: write  # Required for Trusted Publishing (PyPI + npm OIDC)
+      id-token: write  # Required for npm Trusted Publishing (OIDC)
 
     strategy:
       fail-fast: false
@@ -298,12 +297,12 @@ jobs:
           name: Packages-${{ matrix.package }}
           path: dist
 
-      - name: Publish to PyPI (Trusted Publishing)
+      - name: Publish to PyPI
         if: matrix.type == 'python' && steps.check-python.outputs.should_release == 'true'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
         with:
+          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true
-          attestations: true  # Enable with Trusted Publishing
 
       - name: Create Python GitHub Release
         if: matrix.type == 'python' && steps.check-python.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary

PyPI trusted publishing requires specific environment configuration that isn't set up for this repository. This PR fixes the release workflow to use the `PYPI_TOKEN` secret for Python packages while npm continues to use trusted publishing (OIDC).

## Changes

- Remove `environment: pypi` from release job (not needed for token auth)
- Update pypi-publish step to use password instead of OIDC
- Update permission comments to reflect actual usage

## Test Plan

- [ ] CI passes on this PR
- [ ] After merge, release job should succeed using PYPI_TOKEN

Fixes the PyPI publishing failures seen in https://github.com/jbcom/jbcom-control-center/actions/runs/19829757157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit dc4f7561c4e3dc1d9896ee22afa7ffa98d2044f6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->