### PR TITLE
docs: add secrets infrastructure unification tracker

### DIFF
--- a/ecosystems/flipside-crypto/memory-bank/secrets-unification-tracker.md
+++ b/ecosystems/flipside-crypto/memory-bank/secrets-unification-tracker.md
@@ -63,7 +63,7 @@ data-platform-secrets-syncing (SAM pipeline)
 ### Proposed (Unified with vault-secret-sync)
 ```
 OpenBao → Audit Log → vault-secret-sync ┬→ AWS Secrets Manager
-                                        └→ KV2 merge stores
+                                        └→ Also syncs to KV2 merge stores
 ```
 
 ## Next Steps After Decision


### PR DESCRIPTION
## Summary

Adds tracking document for the FSC secrets infrastructure unification work.

## PRs/Issues Tracked

- **data-platform-secrets-syncing**: Greenfielded, 2 proposal PRs (#43, #44)
- **terraform-aws-secretsmanager**: Deprecation PR #52
- **terraform-modules**: Issues #225-229, PR #226
- **cluster-ops**: Deployment PR #154

## Decision Pending

FSC department heads need to select between SAM and vault-secret-sync approaches.

## Related

- [PROPOSAL](https://github.com/FlipsideCrypto/data-platform-secrets-syncing/blob/main/PROPOSAL.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a concise tracker doc outlining proposals, decisions, architecture, and cross-repo actions for secrets infrastructure unification.
> 
> - **Documentation**:
>   - Adds `ecosystems/flipside-crypto/memory-bank/secrets-unification-tracker.md` to track the secrets infrastructure unification effort:
>     - Decision point between SAM and `vault-secret-sync` with linked proposal PRs.
>     - Cross-repo PRs/issues status matrix spanning `data-platform-secrets-syncing`, `terraform-aws-secretsmanager`, `terraform-modules`, and `cluster-ops`.
>     - Architecture comparison (current fragmented vs proposed unified) and key insight on Vault KV2 merge stores.
>     - Post-decision next steps checklist and repository links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d157d5e7915bda79f62194e96beee3914dfb0f20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->