### PR TITLE
Fix github actions sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -44,7 +44,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.sync_secrets != false)
+      (github.event_name == 'workflow_dispatch' && inputs.sync_secrets)
 
     strategy:
       fail-fast: false
@@ -101,7 +101,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.sync_files != false)
+      (github.event_name == 'workflow_dispatch' && inputs.sync_files)
 
     steps:
       # actions/checkout v4.2.2
@@ -142,7 +142,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.sync_branch_protection != false)
+      (github.event_name == 'workflow_dispatch' && inputs.sync_branch_protection)
 
     strategy:
       fail-fast: false
@@ -193,7 +193,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.sync_pages != false)
+      (github.event_name == 'workflow_dispatch' && inputs.sync_pages)
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixes the GitHub Actions sync workflow by correcting the secrets sync action, pinning all actions to SHAs, and adjusting triggers.

The previous workflow failed because `google/secrets-sync-action@v1` does not exist. This PR replaces it with the correct `jpoehnelt/secrets-sync-action`, adds required parameters, pins all actions to specific SHA sums for stability, and ensures all sync jobs run on `push` to `main` by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-b06273bd-87b0-4025-b2d2-f928ce0934f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b06273bd-87b0-4025-b2d2-f928ce0934f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace the secrets sync action, pin all actions to SHAs, broaden triggers to run on push/schedule, and add required inputs/env with dry-run across secrets, file, branch protection, and pages jobs.
> 
> - **CI Workflow (`.github/workflows/sync.yml`)**:
>   - **Triggers/conditions**: Run jobs on `push`, `schedule`, or `workflow_dispatch` unless explicitly disabled; add unified `dry_run` handling.
>   - **Action pinning**: Pin `jpoehnelt/secrets-sync-action`, `actions/checkout`, and `BetaHuhn/repo-file-sync-action` to specific SHAs.
>   - **Secrets Sync**:
>     - Replace `google/secrets-sync-action@v1` with `jpoehnelt/secrets-sync-action`.
>     - Provide `github_token`, explicit `repositories` with `repositories_list_regex: "false"`, and regex-based `secrets` list; set env mappings for each secret.
>   - **File Sync**:
>     - Use pinned repo-file-sync action; configure `GH_PAT`, `CONFIG_PATH`, labels, commit prefix, PR body, and `DRY_RUN`.
>   - **Branch Protection & Pages**:
>     - Apply same trigger logic and `dry_run` paths; use `gh api` to set branch protection and enable Pages with `build_type: workflow`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aaa8c6a412ddbdb9179e132708145da22178a92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->