### PR TITLE
feat(ci): add AI test generation workflow with Claude 4.5

### DIFF
--- a/.github/workflows/generate-tests.yml
+++ b/.github/workflows/generate-tests.yml
@@ -404,7 +404,12 @@ jobs:
           echo "| Branch | \`${{ inputs.base_branch }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **Effective Coverage Threshold** | **${{ steps.threshold.outputs.effective_threshold }}%** |" >> $GITHUB_STEP_SUMMARY
           echo "| Workflow Standard | ${{ inputs.coverage_threshold }}% |" >> $GITHUB_STEP_SUMMARY
-          echo "| pyproject.toml Value | ${{ steps.threshold.outputs.pyproject_threshold || 'N/A' }}% |" >> $GITHUB_STEP_SUMMARY
+          PYPROJECT_VAL="${{ steps.threshold.outputs.pyproject_threshold }}"
+          if [ -n "$PYPROJECT_VAL" ]; then
+            echo "| pyproject.toml Value | ${PYPROJECT_VAL}% |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| pyproject.toml Value | N/A |" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "| Using pyproject.toml? | ${{ inputs.use_pyproject_coverage }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Modules Found | ${{ steps.discover.outputs.module_count }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Model | \`${{ inputs.model }}\` |" >> $GITHUB_STEP_SUMMARY
@@ -503,7 +508,7 @@ jobs:
 
           claude_args: |
             --model "${{ inputs.model }}"
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(pytest:*),Bash(python:*),Bash(pip:*)"
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(pytest:*)"
           track_progress: true
 
       - name: Get changed files
@@ -745,7 +750,7 @@ jobs:
 
           claude_args: |
             --model "${{ inputs.model }}"
-            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(pytest:*),Bash(python:*)"
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(pytest:*)"
 
       - name: Verify fixes and push
         id: verify-push
@@ -887,7 +892,7 @@ jobs:
 
           claude_args: |
             --model "${{ inputs.model }}"
-            --allowedTools "Edit,Read,Write"
+            --allowedTools "Edit,Read"
 
       - name: Commit and push pyproject.toml update
         run: |


### PR DESCRIPTION
## Summary

Adds a new `generate-tests.yml` workflow for automated AI-powered test generation across jbcom Python repositories.

## Features

### Model Selection (from platform.claude.com/docs)
- `claude-haiku-4-5` - Fastest ($1/$5 per MTok) **[DEFAULT]**
- `claude-sonnet-4-5` - Balanced ($3/$15 per MTok)
- `claude-opus-4-5` - Most capable ($5/$25 per MTok)

### Target Repositories
- jbcom/extended-data-types
- jbcom/lifecyclelogging
- jbcom/directed-inputs-class
- jbcom/python-terraform-bridge
- jbcom/vendor-connectors
- jbcom/agentic-crew
- jbcom/jbcom-oss-ecosystem

### Coverage Enforcement
- **Default: 100% coverage target** (enforced workflow standard)
- Checkbox `use_pyproject_coverage` to optionally read from pyproject.toml instead
- After tests pass, **automatically updates pyproject.toml** with achieved coverage
- Ensures coverage can only go **UP**, never down

### Key Capabilities
- Code coverage analysis to identify untested modules
- Dynamic matrix jobs (toJSON) for parallel test generation
- Uses `tj-actions/changed-files` for file tracking
- Uses `peter-evans/create-pull-request` for PR creation
- Uses `anthropics/claude-code-action` for:
  - Test generation
  - Auto-fixing failing tests
  - Updating pyproject.toml coverage threshold
- Dry run mode for analysis only

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test dry run mode on a target repo
- [ ] Test actual generation with claude-haiku-4-5
- [ ] Verify pyproject.toml gets updated after successful test generation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a GitHub Actions workflow that analyzes coverage, generates and auto-fixes tests with Claude, opens a PR, and updates pyproject coverage thresholds.
> 
> - **CI Workflow (`.github/workflows/generate-tests.yml`)**
>   - **Inputs/Config**: Repository selection, Claude model, base branch, coverage options (workflow vs. pyproject), max parallel jobs, dry-run, auto-fix; Python 3.12.
>   - **Analyze**: Checks out target repo, determines effective coverage threshold (optionally from `pyproject.toml`), installs deps, runs coverage, discovers untested modules, groups them for parallel jobs, and summarizes findings.
>   - **Generate**: Matrix job per module group; installs deps; uses `anthropics/claude-code-action` to create pytest tests targeting the threshold; uploads generated test artifacts.
>   - **Consolidate**: Downloads artifacts, verifies tests, detects changed test files, and creates a PR with details using `peter-evans/create-pull-request`.
>   - **Auto-Fix**: If failures, re-runs tests, invokes Claude to fix tests only, commits/pushes fixes, and comments on the PR with status.
>   - **Update pyproject**: Measures achieved coverage and updates `pyproject.toml` (`fail_under` or `--cov-fail-under`) to the achieved value (never lowering), commits, and comments on the PR.
>   - **Summary**: Final job posts configuration and per-job status; uses `tj-actions/changed-files`, artifact upload/download, and GitHub Step Summary for reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d24a9252f8c82358c269a442bc0413053464fb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->