### PR TITLE
fix(sync): update workflow matrices to include all 18 repositories

### DIFF
--- a/.github/workflows/generate-tests.yml
+++ b/.github/workflows/generate-tests.yml
@@ -8,13 +8,14 @@ on:
         required: true
         type: choice
         options:
+          - jbcom/agentic-crew
+          - jbcom/ai_game_dev
+          - jbcom/directed-inputs-class
           - jbcom/extended-data-types
           - jbcom/lifecyclelogging
-          - jbcom/directed-inputs-class
           - jbcom/python-terraform-bridge
+          - jbcom/rivers-of-reckoning
           - jbcom/vendor-connectors
-          - jbcom/agentic-crew
-          - jbcom/jbcom-oss-ecosystem
         default: jbcom/extended-data-types
       model:
         description: "Anthropic model to use"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -50,13 +50,28 @@ jobs:
       fail-fast: false
       matrix:
         repo:
+          # Python packages
+          - jbcom/agentic-crew
+          - jbcom/ai_game_dev
+          - jbcom/directed-inputs-class
           - jbcom/extended-data-types
           - jbcom/lifecyclelogging
-          - jbcom/directed-inputs-class
           - jbcom/python-terraform-bridge
+          - jbcom/rivers-of-reckoning
           - jbcom/vendor-connectors
+          # Node.js / TypeScript packages
           - jbcom/agentic-control
+          - jbcom/otter-river-rush
+          - jbcom/otterfall
+          - jbcom/pixels-pygame-palace
+          - jbcom/rivermarsh
+          - jbcom/strata
+          # Go packages
+          - jbcom/port-api
           - jbcom/vault-secret-sync
+          # Terraform modules
+          - jbcom/terraform-github-markdown
+          - jbcom/terraform-repository-automation
 
     steps:
       - name: Sync secrets to ${{ matrix.repo }}
@@ -140,13 +155,28 @@ jobs:
       fail-fast: false
       matrix:
         repo:
+          # Python packages
+          - jbcom/agentic-crew
+          - jbcom/ai_game_dev
+          - jbcom/directed-inputs-class
           - jbcom/extended-data-types
           - jbcom/lifecyclelogging
-          - jbcom/directed-inputs-class
           - jbcom/python-terraform-bridge
+          - jbcom/rivers-of-reckoning
           - jbcom/vendor-connectors
+          # Node.js / TypeScript packages
           - jbcom/agentic-control
+          - jbcom/otter-river-rush
+          - jbcom/otterfall
+          - jbcom/pixels-pygame-palace
+          - jbcom/rivermarsh
+          - jbcom/strata
+          # Go packages
+          - jbcom/port-api
           - jbcom/vault-secret-sync
+          # Terraform modules
+          - jbcom/terraform-github-markdown
+          - jbcom/terraform-repository-automation
 
     steps:
       - name: Apply branch protection to ${{ matrix.repo }}
@@ -189,12 +219,28 @@ jobs:
       fail-fast: false
       matrix:
         repo:
+          # Python packages
+          - jbcom/agentic-crew
+          - jbcom/ai_game_dev
+          - jbcom/directed-inputs-class
           - jbcom/extended-data-types
           - jbcom/lifecyclelogging
-          - jbcom/directed-inputs-class
           - jbcom/python-terraform-bridge
+          - jbcom/rivers-of-reckoning
           - jbcom/vendor-connectors
+          # Node.js / TypeScript packages
           - jbcom/agentic-control
+          - jbcom/otter-river-rush
+          - jbcom/otterfall
+          - jbcom/pixels-pygame-palace
+          - jbcom/rivermarsh
+          - jbcom/strata
+          # Go packages
+          - jbcom/port-api
+          - jbcom/vault-secret-sync
+          # Terraform modules
+          - jbcom/terraform-github-markdown
+          - jbcom/terraform-repository-automation
 
     steps:
       - name: Enable GitHub Pages for ${{ matrix.repo }}


### PR DESCRIPTION
## Summary

- Updated `sync.yml` workflow to include ALL 18 repositories in each matrix job (sync-secrets, sync-branch-protection, sync-pages)
- Updated `generate-tests.yml` to include all 8 Python repositories
- Removed obsolete `jbcom/jbcom-oss-ecosystem` from generate-tests options

## Context

PR #348 updated `.github/sync.yml` (the file sync config) with all repos, but the workflow file matrices were not updated. This caused secrets, branch protection, and GitHub Pages to only sync to 7 repos instead of 18.

## Repositories Now Included

| Category | Count | Repos |
|----------|-------|-------|
| Python | 8 | agentic-crew, ai_game_dev, directed-inputs-class, extended-data-types, lifecyclelogging, python-terraform-bridge, rivers-of-reckoning, vendor-connectors |
| Node.js/TypeScript | 6 | agentic-control, otter-river-rush, otterfall, pixels-pygame-palace, rivermarsh, strata |
| Go | 2 | port-api, vault-secret-sync |
| Terraform | 2 | terraform-github-markdown, terraform-repository-automation |
| **Total** | **18** | |

## Test plan

- [ ] CI passes (workflow lint validation)
- [ ] Run `sync.yml` workflow in dry-run mode to verify all repos are targeted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands sync workflow matrices to 18 repositories across languages and updates generate-tests to list all 8 Python repos.
> 
> - **Workflows**:
>   - **Sync (`.github/workflows/sync.yml`)**:
>     - Expand matrices for `sync-secrets`, `sync-branch-protection`, and `sync-pages` to target 18 repos across categories:
>       - Python: `agentic-crew`, `ai_game_dev`, `directed-inputs-class`, `extended-data-types`, `lifecyclelogging`, `python-terraform-bridge`, `rivers-of-reckoning`, `vendor-connectors`
>       - Node/TS: `agentic-control`, `otter-river-rush`, `otterfall`, `pixels-pygame-palace`, `rivermarsh`, `strata`
>       - Go: `port-api`, `vault-secret-sync`
>       - Terraform: `terraform-github-markdown`, `terraform-repository-automation`
>   - **Generate Tests (`.github/workflows/generate-tests.yml`)**:
>     - Update `repository` input options to include all 8 Python repos; remove obsolete `jbcom/jbcom-oss-ecosystem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43d383f6946addae178485371855a36d0a23905b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->