### PR TITLE
docs: secretsync management takeover

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,33 @@
 # Active Context - jbcom Control Center
 
-## Current Status: REPOSITORY AUDIT COMPLETE
+## Current Status: SECRETSYNC MANAGEMENT TAKEOVER
+
+Taking over management of jbcom/secretsync - the new home for vault-secret-sync fork. Managing 9 outstanding PRs and orchestrating merge sequence.
+
+### SecretSync PRs (All marked Ready for Review)
+
+| PR | Title | Status | Dependencies |
+|----|-------|--------|--------------|
+| #17 | Replace Slack webhook placeholders | ✅ Ready | None - merge first |
+| #11 | Rename binary vss → secretsync | ✅ Ready | None - foundational |
+| #12 | Rebrand Helm charts to secretsync | ✅ Ready | After #11 conceptually |
+| #10 | AWS Organizations dynamic discovery | ✅ Ready | Independent |
+| #13 | Integrate diff tracking | 🔄 WIP | Only initial plan |
+| #14 | S3 merge store read operations | 🔄 WIP | Only initial plan |
+| #15 | Add comprehensive test coverage | 🔄 WIP | Only initial plan |
+| #16 | Set up CI/CD workflows | 🔄 WIP | Only initial plan |
+| #19 | GitHub Marketplace Action | 🔄 WIP | Partial implementation |
+
+### Recommended Merge Order
+1. **PR #17** - Simple webhook cleanup, no deps
+2. **PR #11** - Binary rename (foundational rebrand)
+3. **PR #12** - Helm chart rebrand  
+4. **PR #10** - AWS Organizations discovery feature
+5. Wait for WIP PRs to complete implementation
+
+---
+
+## Previous Status: REPOSITORY AUDIT COMPLETE
 
 Reviewed all open PRs, issues, and projects across jbcom repos. Cleaned up stale/invalid PRs and added new rivermarsh repo to sync config.
 
@@ -68,7 +95,7 @@ Reviewed all open PRs, issues, and projects across jbcom repos. Cleaned up stale
 | Repository | Description |
 |------------|-------------|
 | jbcom/port-api | Port API for multiple languages |
-| jbcom/vault-secret-sync | HashiCorp Vault secret sync |
+| jbcom/secretsync | Universal multi-cloud secret sync (replaces vault-secret-sync) |
 
 **Terraform/HCL Modules:**
 | Repository | Description |


### PR DESCRIPTION
## Summary

Session hold-open PR documenting the takeover of jbcom/secretsync repository management.

### SecretSync Status

Taking over management of [jbcom/secretsync](https://github.com/jbcom/secretsync) - the new home for the vault-secret-sync fork.

**9 PRs marked Ready for Review:**
- PR #17 - Replace Slack webhook placeholders (merge first)
- PR #11 - Rename binary vss → secretsync 
- PR #12 - Rebrand Helm charts to secretsync
- PR #10 - AWS Organizations dynamic discovery
- PR #13, #14, #15, #16, #19 - WIP (initial plans only)

### Recommended Merge Order
1. PR #17 - Simple webhook cleanup, no deps
2. PR #11 - Binary rename (foundational rebrand)
3. PR #12 - Helm chart rebrand  
4. PR #10 - AWS Organizations discovery feature
5. Wait for WIP PRs to complete implementation

## Test plan
- [x] Memory bank updated with secretsync status
- [ ] Sync config update on main branch
- [ ] Trigger sync workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `memory-bank/activeContext.md` to reflect SecretSync management takeover with PR statuses/merge order and replaces Go repo reference to `secretsync`.
> 
> - **Docs (memory bank)**:
>   - Update current status to SecretSync management takeover; add context on managing `jbcom/secretsync`.
>   - Add table of 9 SecretSync PRs with statuses/dependencies and a recommended merge order.
>   - Retain prior audit under a new "Previous Status" section.
> - **Repo references**:
>   - Replace Go package `jbcom/vault-secret-sync` with `jbcom/secretsync`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68f42feddc6f0d856fa8b045041aec64465739c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->