### PR TITLE
docs: update memory bank for secretsync management session

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -68,7 +68,7 @@ Reviewed all open PRs, issues, and projects across jbcom repos. Cleaned up stale
 | Repository | Description |
 |------------|-------------|
 | jbcom/port-api | Port API for multiple languages |
-| jbcom/vault-secret-sync | HashiCorp Vault secret sync |
+| jbcom/secretsync | Cross-platform secret synchronization (formerly vault-secret-sync) |
 
 **Terraform/HCL Modules:**
 | Repository | Description |


### PR DESCRIPTION
## Summary
- Updates memory bank to reference `jbcom/secretsync` rebrand (formerly `vault-secret-sync`)

## Context
This is a **hold-open PR** for the secretsync management session. The actual sync workflow updates are being pushed directly to main as requested.

## Related
- jbcom/secretsync repository takeover and management
- Sync workflow updates to rename vault-secret-sync → secretsync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `jbcom/vault-secret-sync` with `jbcom/secretsync` in the Go Packages list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf630eaf29bc4851f9e8e78d3a8823e1fb99e4f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->