### PR TITLE
refactor(sync): rename vault-secret-sync to secretsync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -76,7 +76,7 @@ jobs:
           - jbcom/strata
           # Go packages
           - jbcom/port-api
-          - jbcom/vault-secret-sync
+          - jbcom/secretsync
           # Terraform modules
           - jbcom/terraform-github-markdown
           - jbcom/terraform-repository-automation
@@ -195,7 +195,7 @@ jobs:
           # Go packages
           - repo: jbcom/port-api
             eslint: false
-          - repo: jbcom/vault-secret-sync
+          - repo: jbcom/secretsync
             eslint: false
           # Terraform modules
           - repo: jbcom/terraform-github-markdown
@@ -356,7 +356,7 @@ jobs:
           - jbcom/strata
           # Go packages
           - jbcom/port-api
-          - jbcom/vault-secret-sync
+          - jbcom/secretsync
           # Terraform modules
           - jbcom/terraform-github-markdown
           - jbcom/terraform-repository-automation
@@ -440,7 +440,7 @@ jobs:
           - jbcom/strata
           # Go packages
           - jbcom/port-api
-          - jbcom/vault-secret-sync
+          - jbcom/secretsync
           # Terraform modules
           - jbcom/terraform-github-markdown
           - jbcom/terraform-repository-automation
@@ -509,7 +509,7 @@ jobs:
           - jbcom/strata
           # Go packages
           - jbcom/port-api
-          - jbcom/vault-secret-sync
+          - jbcom/secretsync
           # Terraform modules
           - jbcom/terraform-github-markdown
           - jbcom/terraform-repository-automation


### PR DESCRIPTION
## Summary
- Renames `jbcom/vault-secret-sync` → `jbcom/secretsync` in sync workflow matrix entries

## Context
The vault-secret-sync repository has been rebranded to secretsync. This updates all sync workflow matrices to use the new name:
- Secrets sync
- Rulesets sync
- Repository settings sync
- Code scanning sync
- GitHub Pages sync

## Urgency
This is a configuration fix needed to enable proper sync operations to the secretsync repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames workflow matrix references from `jbcom/vault-secret-sync` to `jbcom/secretsync` across all sync jobs.
> 
> - **Workflows: `.github/workflows/sync.yml`**
>   - Replace `jbcom/vault-secret-sync` with `jbcom/secretsync` in matrix entries for:
>     - Secrets sync
>     - Rulesets sync
>     - Repository settings sync
>     - Code scanning sync
>     - GitHub Pages sync
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff32f2d655982a46ce5836810230a6252912794b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->