### PR TITLE
fix(terraform): revert to local backend - HCP Terraform has no token

### DIFF
--- a/.github/workflows/terraform-sync.yml
+++ b/.github/workflows/terraform-sync.yml
@@ -44,7 +44,6 @@ jobs:
       # - admin:org (read) - for organization membership checks
       # - workflow (write) - for GitHub Actions workflow modifications
       GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-      TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
       
       # Secrets to sync to all repositories via Terraform
       # These are passed as TF_VAR_* environment variables
@@ -68,8 +67,6 @@ jobs:
         with:
           terraform_version: "1.14.1"
           terraform_wrapper: false
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-          cli_config_credentials_hostname: app.terraform.io
 
       - name: Setup Terragrunt
         run: |

--- a/terragrunt-stacks/terragrunt.hcl
+++ b/terragrunt-stacks/terragrunt.hcl
@@ -36,19 +36,16 @@ provider "github" {
 EOF
 }
 
-# Use HCP Terraform (Terraform Cloud) for secure remote state
-# Requires TF_API_TOKEN secret in GitHub Actions
+# Use local backend for state
+# State is stored locally - for repo config this is fine since Terraform
+# will reconcile against actual GitHub repo state on each run
 generate "backend" {
   path      = "backend.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<EOF
 terraform {
-  cloud {
-    organization = "jbcom"
-    
-    workspaces {
-      name = "jbcom-repo-${basename(get_terragrunt_dir())}"
-    }
+  backend "local" {
+    path = "terraform.tfstate"
   }
 }
 EOF


### PR DESCRIPTION
Commit 76881340 broke main by switching to HCP Terraform cloud backend without having TF_API_TOKEN configured.

This reverts to local backend which works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts Terraform backend to local state and removes Terraform Cloud credentials/configuration from the CI workflow.
> 
> - **Infrastructure (Terragrunt/Terraform)**:
>   - **Backend**: Replace Terraform Cloud workspace configuration with a local `backend "local"` storing `terraform.tfstate` in `terragrunt-stacks/terragrunt.hcl`.
> - **CI (GitHub Actions)**:
>   - **Remove Terraform Cloud credentials**: Delete `TF_TOKEN_app_terraform_io` env and `cli_config_credentials_*` options from `.github/workflows/terraform-sync.yml` `setup-terraform` step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc3e08cf88fe663d6d83655129e965dd9e276798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->