### PR TITLE
Repository import consistency check

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,23 @@
 # Active Context - jbcom Control Center
 
-## Current Status: TERRAGRUNT REPOSITORY MANAGEMENT
+## Current Status: TERRAGRUNT REPOSITORY MANAGEMENT - IMPORT FIX
+
+Fixed import issue for strata repository's Main ruleset.
+
+### Session: 2025-12-13 (Import Fix)
+
+**Issue**: CI failing with "Name must be unique" error for strata's Main ruleset
+**Root Cause**: strata's "Main" ruleset (ID: 11068179) was created manually on 2025-12-12, before Terraform started managing repos on 2025-12-13
+**Fix**: Added `import` block to `terragrunt-stacks/nodejs/strata/terragrunt.hcl` to import existing ruleset
+
+**Verified**:
+- All 18 repositories exist in GitHub ✅
+- All other repos have "Main" rulesets created by Terraform (2025-12-13T17:07) ✅
+- Only strata needed import (pre-existing ruleset from 2025-12-12) ✅
+
+---
+
+## Previous Status: TERRAGRUNT REPOSITORY MANAGEMENT
 
 Migrating from passive bash script sync to active Terragrunt-managed repository configuration with file synchronization.
 

--- a/terragrunt-stacks/nodejs/strata/terragrunt.hcl
+++ b/terragrunt-stacks/nodejs/strata/terragrunt.hcl
@@ -21,3 +21,18 @@ inputs = merge(
     has_pages       = true
   }
 )
+
+# Import the Main ruleset that was created manually on 2025-12-12 (before Terraform management)
+# The repository itself is already in state from previous runs
+generate "imports" {
+  path      = "imports.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+# Main ruleset was created manually on 2025-12-12 (ID: 11068179)
+# Must import to avoid "Name must be unique" error
+import {
+  to = github_repository_ruleset.main
+  id = "strata:11068179"
+}
+EOF
+}


### PR DESCRIPTION
Add import block for `strata` repository's GitHub ruleset to fix "Name must be unique" error.

The "Main" ruleset for the `strata` repository was manually created before Terraform began managing repositories, causing a conflict when Terraform attempted to create a duplicate. This PR imports the existing ruleset into Terraform state.

---
<a href="https://cursor.com/background-agent?bcId=bc-a02dcb35-7152-4f79-a96d-d50d2d6c7035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a02dcb35-7152-4f79-a96d-d50d2d6c7035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Terragrunt import for `strata`'s existing "Main" GitHub ruleset (ID 11068179) to fix CI "Name must be unique" failures and updates context docs.
> 
> - **Terragrunt**:
>   - Add `generate "imports"` in `terragrunt-stacks/nodejs/strata/terragrunt.hcl` to create `imports.tf` importing `github_repository_ruleset.main` with ID `strata:11068179` (pre-existing "Main" ruleset) to prevent duplicate-name conflicts.
> - **Docs**:
>   - Update `memory-bank/activeContext.md` with import fix session, root cause, and verification notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 058daca6c8ee8662e07c2e5fc1c7bd85ec07b284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->