### PR TITLE
feat: Add Docker Hub Terraform management (experimental)

### DIFF
--- a/terragrunt-stacks/dockerhub/terragrunt.hcl
+++ b/terragrunt-stacks/dockerhub/terragrunt.hcl
@@ -1,0 +1,141 @@
+# Docker Hub stack - provisions Docker Hub repositories for container images
+#
+# Usage:
+#   cd terragrunt-stacks/dockerhub
+#   terragrunt init
+#   terragrunt plan
+#   terragrunt apply
+#
+# Prerequisites:
+#   - DOCKERHUB_USERNAME and DOCKERHUB_TOKEN environment variables
+#   - Same credentials used in GitHub Actions secrets
+#
+# NOTE: This stack does NOT include the root config because it needs
+# the dockerhub provider instead of the GitHub provider.
+
+terraform {
+  source = "../modules/dockerhub"
+}
+
+# Configure backend - use dedicated workspace for Docker Hub
+generate "backend" {
+  path      = "backend.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  cloud {
+    organization = "jbcom"
+
+    workspaces {
+      name = "jbcom-dockerhub"
+    }
+  }
+}
+EOF
+}
+
+# Configure provider - Docker Hub provider
+# Uses DOCKERHUB_USERNAME and DOCKERHUB_TOKEN environment variables
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    dockerhub = {
+      source  = "artificialinc/dockerhub"
+      version = "~> 0.0.15"
+    }
+  }
+}
+
+# Docker Hub provider uses environment variables:
+# - DOCKERHUB_USERNAME
+# - DOCKERHUB_TOKEN (same as DOCKERHUB_PASSWORD)
+provider "dockerhub" {}
+EOF
+}
+
+locals {
+  # Docker Hub namespace (same as GitHub owner for consistency)
+  namespace = "jbdevprimary"
+
+  # Repositories to create on Docker Hub
+  # These are the packages that publish Docker images
+  docker_repos = {
+    "agentic-control" = {
+      description      = "AI agent fleet management and control plane"
+      full_description = <<-EOT
+# agentic-control
+
+AI agent fleet management, sandboxed execution, and control plane.
+
+## Quick Start
+
+```bash
+docker pull jbdevprimary/agentic-control:latest
+docker run --rm jbdevprimary/agentic-control --help
+```
+
+## Features
+
+- Fleet management for AI agents
+- Sandboxed Docker execution
+- Process lifecycle management
+- Multi-framework support (CrewAI, LangGraph, Strands)
+
+## Links
+
+- [GitHub](https://github.com/jbdevprimary/agentic-control)
+- [npm](https://www.npmjs.com/package/agentic-control)
+EOT
+    }
+
+    "agentic-triage" = {
+      description      = "AI-powered GitHub issue triage, PR review, and sprint planning"
+      full_description = <<-EOT
+# agentic-triage
+
+AI-powered GitHub issue triage, PR review, and sprint planning CLI.
+
+## Quick Start
+
+```bash
+docker pull jbdevprimary/agentic-triage:latest
+docker run --rm -e GH_TOKEN -e OLLAMA_API_KEY jbdevprimary/agentic-triage assess 123
+```
+
+## Features
+
+- Issue assessment and auto-labeling
+- AI-powered PR code review
+- Sprint planning with AI
+- Security scanning and CodeQL analysis
+- Release automation
+
+## GitHub Action
+
+```yaml
+- uses: jbdevprimary/agentic-triage@v0.2.0
+  with:
+    command: assess
+    issue: \${{ github.event.issue.number }}
+    github_token: \${{ secrets.GITHUB_TOKEN }}
+    ollama_api_key: \${{ secrets.OLLAMA_API_KEY }}
+```
+
+## Links
+
+- [GitHub](https://github.com/jbdevprimary/agentic-triage)
+- [npm](https://www.npmjs.com/package/agentic-triage)
+- [GitHub Action](https://github.com/marketplace/actions/agentic-triage)
+EOT
+    }
+  }
+}
+
+inputs = {
+  namespace    = local.namespace
+  repositories = local.docker_repos
+}

--- a/terragrunt-stacks/modules/dockerhub/main.tf
+++ b/terragrunt-stacks/modules/dockerhub/main.tf
@@ -1,0 +1,61 @@
+# Docker Hub Repository Module
+# Manages Docker Hub repositories using the artificialinc/dockerhub provider
+#
+# Usage:
+#   module "dockerhub" {
+#     source = "../modules/dockerhub"
+#
+#     repositories = {
+#       "agentic-triage" = {
+#         description = "AI-powered GitHub issue triage"
+#         private     = false
+#       }
+#     }
+#   }
+
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    dockerhub = {
+      source  = "artificialinc/dockerhub"
+      version = "~> 0.0.15"
+    }
+  }
+}
+
+variable "namespace" {
+  type        = string
+  description = "Docker Hub namespace (username or organization)"
+  default     = "jbdevprimary"
+}
+
+variable "repositories" {
+  type = map(object({
+    description      = optional(string, "")
+    private          = optional(bool, false)
+    full_description = optional(string, "")
+  }))
+  description = "Map of repository names to their configurations"
+}
+
+# Create Docker Hub repositories
+resource "dockerhub_repository" "repo" {
+  for_each = var.repositories
+
+  namespace        = var.namespace
+  name             = each.key
+  description      = each.value.description
+  private          = each.value.private
+  full_description = each.value.full_description != "" ? each.value.full_description : each.value.description
+}
+
+output "repositories" {
+  value = {
+    for name, repo in dockerhub_repository.repo : name => {
+      namespace = repo.namespace
+      name      = repo.name
+      url       = "https://hub.docker.com/r/${repo.namespace}/${repo.name}"
+    }
+  }
+  description = "Created Docker Hub repositories"
+}


### PR DESCRIPTION
## Summary

Experimental: Add Terraform management for Docker Hub repositories.

Uses the [artificialinc/dockerhub](https://registry.terraform.io/providers/artificialinc/dockerhub/latest/docs) provider with same credentials as GitHub Actions.

## Repositories

- `jbdevprimary/agentic-control`
- `jbdevprimary/agentic-triage`

## Fallback

If this is too much hassle, we have GHCR already working:
- `ghcr.io/jbdevprimary/agentic-control`
- `ghcr.io/jbdevprimary/agentic-triage`

## Prerequisites

Environment variables (same as GH Actions secrets):
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

## Test plan

- [ ] Create TFC workspace `jbcom-dockerhub`
- [ ] Run terragrunt plan
- [ ] Verify repos are created
- [ ] If painful, close PR and rely on GHCR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a Terraform module and Terragrunt stack to provision/manage Docker Hub repos (agentic-control, agentic-triage) via the artificialinc/dockerhub provider with a TFC backend.
> 
> - **Infrastructure**:
>   - **Terragrunt stack** (`terragrunt-stacks/dockerhub/terragrunt.hcl`):
>     - Configures Terraform Cloud workspace `jbcom-dockerhub` and `artificialinc/dockerhub` provider.
>     - Defines namespace `jbdevprimary` and repositories `agentic-control` and `agentic-triage` with detailed `full_description`.
>     - Passes inputs to module (`namespace`, `repositories`).
>   - **Terraform module** (`terragrunt-stacks/modules/dockerhub/main.tf`):
>     - Declares `dockerhub_repository` resources for each repo with `description`, `private`, and `full_description`.
>     - Outputs created repo metadata including URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0776cfb819cd7e27f097dd3bcfc9642ea5a08cbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->