### PR TITLE
fix: Remove GitHub Actions template syntax from Docker Hub HCL

### DIFF
--- a/terragrunt-stacks/dockerhub/terragrunt.hcl
+++ b/terragrunt-stacks/dockerhub/terragrunt.hcl
@@ -116,14 +116,7 @@ docker run --rm -e GH_TOKEN -e OLLAMA_API_KEY jbdevprimary/agentic-triage assess
 
 ## GitHub Action
 
-```yaml
-- uses: jbdevprimary/agentic-triage@v0.2.0
-  with:
-    command: assess
-    issue: \${{ github.event.issue.number }}
-    github_token: \${{ secrets.GITHUB_TOKEN }}
-    ollama_api_key: \${{ secrets.OLLAMA_API_KEY }}
-```
+See [GitHub](https://github.com/jbdevprimary/agentic-triage) for GitHub Action usage.
 
 ## Links
 


### PR DESCRIPTION
Fix HCL parse error - ${{ }} syntax breaks terragrunt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the GitHub Action YAML example in `terragrunt-stacks/dockerhub/terragrunt.hcl` with a link to GitHub usage within the `agentic-triage` repository description.
> 
> - **Docker Hub stack (`terragrunt-stacks/dockerhub/terragrunt.hcl`)**:
>   - In `docker_repos["agentic-triage"].full_description`, remove the inline GitHub Action YAML example and replace it with a link to GitHub for usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 956bb8fc381011f32ce9c9bb947ca839f90ed893. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->