### PR TITLE
fix: Remove duplicate required_providers from dockerhub module

### DIFF
--- a/terragrunt-stacks/modules/dockerhub/main.tf
+++ b/terragrunt-stacks/modules/dockerhub/main.tf
@@ -13,15 +13,8 @@
 #     }
 #   }
 
-terraform {
-  required_version = ">= 1.5.0"
-  required_providers {
-    dockerhub = {
-      source  = "artificialinc/dockerhub"
-      version = "~> 0.0.15"
-    }
-  }
-}
+# Note: required_providers is defined in terragrunt generate "provider" block
+# Do not add terraform {} block here to avoid conflicts
 
 variable "namespace" {
   type        = string


### PR DESCRIPTION
Terragrunt generates provider.tf with required_providers, so remove it from the module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `terraform { required_providers ... }` block from `modules/dockerhub/main.tf` to rely on Terragrunt-generated providers and avoid conflicts.
> 
> - **Modules/dockerhub**:
>   - Remove duplicate `terraform { required_providers ... }` block from `modules/dockerhub/main.tf`.
>   - Add note clarifying providers are generated by Terragrunt to prevent conflicts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47639f85efdf40ed65bf87cc6ca60f3859908df8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->