### PR TITLE
fix: Add Docker Hub provider env vars

### DIFF
--- a/.github/workflows/terraform-sync.yml
+++ b/.github/workflows/terraform-sync.yml
@@ -60,6 +60,9 @@ jobs:
       TF_VAR_npm_token: ${{ secrets.NPM_TOKEN }}
       TF_VAR_dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       TF_VAR_dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Docker Hub provider auth (non-TF_VAR for provider)
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       TF_VAR_ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
 


### PR DESCRIPTION
The dockerhub provider needs DOCKERHUB_USERNAME and DOCKERHUB_TOKEN environment variables (not TF_VAR_ prefixed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to `.github/workflows/terraform-sync.yml` for Docker Hub provider authentication (non-`TF_VAR_*`).
> 
> - **CI/Workflow**
>   - Update `.github/workflows/terraform-sync.yml` to include non-`TF_VAR_*` env vars for Docker Hub provider auth:
>     - `DOCKERHUB_USERNAME`
>     - `DOCKERHUB_TOKEN`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b309f00ccc42b85a28a91c713cdf298dc51fdfe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->