### PR TITLE
fix: Import existing agentic-triage repo into Terraform state

### DIFF
--- a/terragrunt-stacks/nodejs/agentic-triage/terragrunt.hcl
+++ b/terragrunt-stacks/nodejs/agentic-triage/terragrunt.hcl
@@ -6,6 +6,18 @@ terraform {
   source = "../../modules/repository"
 }
 
+# Import existing repo created outside of Terraform
+generate "imports" {
+  path      = "imports.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+import {
+  to = github_repository.this
+  id = "agentic-triage"
+}
+EOF
+}
+
 locals {
   root_config = read_terragrunt_config(find_in_parent_folders())
   common      = local.root_config.locals.common_settings


### PR DESCRIPTION
Add import block for agentic-triage repo created outside Terraform

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Terragrunt `generate` block to import the existing `agentic-triage` GitHub repository into Terraform state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86778748a20c9d579dd7bd2f5680dd36f22b1bf8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->