### PR TITLE
Clarify Triage Hub documentation

### DIFF
--- a/docs/TRIAGE-HUB.md
+++ b/docs/TRIAGE-HUB.md
@@ -10,14 +10,14 @@ The **agentic-triage** workflow keeps jbcom issues and pull requests synchronize
 ## Documentation discovery across languages
 1. **Initialize submodules**: run `git submodule update --init --recursive` so `ecosystems/oss/` contains the downstream packages defined in `.gitmodules`.
 2. **Language-specific doc roots** (available after checkout):
-   - **TypeScript**: `ecosystems/oss/agentic-control/` (CLI and automation) and `ecosystems/oss/agentic-triage/` expose README plus `/docs` content consumed by the workflow.
-   - **Python**: `ecosystems/oss/agentic-crew/` (crew orchestration) and `ecosystems/oss/vendor-connectors/` (provider plugins) provide README/doc folders used for prompt and guidance lookup.
-   - **Go / Rust**: new submodules under `ecosystems/oss/<repo>/` follow the same pattern; once the repo is checked out, `agentic-triage` traverses README and `/docs` directories so language-agnostic lookups keep working without extra cloning.
+   - **TypeScript**: `ecosystems/oss/agentic-control/` (CLI and automation) and `ecosystems/oss/agentic-triage/` expose `README` and `/docs` content consumed by the workflow.
+   - **Python**: `ecosystems/oss/agentic-crew/` (crew orchestration) and `ecosystems/oss/vendor-connectors/` (provider plugins) provide `README` and `/docs` folders used for prompt and guidance lookup.
+   - **Go / Rust**: new submodules under `ecosystems/oss/<repo>/` follow the same pattern; once the repo is checked out, `agentic-triage` traverses `README` and `/docs` directories so language-agnostic lookups keep working without extra cloning.
 3. **Lookup strategy**: during CI runs, `agentic-triage` reads those checked-out paths locally, so language documentation is available to the action without hitting the network.
 
 ## MCP-aware environment variables
 - All downstream packages honor the precedence defined in `docs/ENVIRONMENT_VARIABLES.md`: CLI flags and explicit options win, then `COPILOT_MCP_*` variables (e.g., `COPILOT_MCP_CURSOR_API_KEY`, `COPILOT_MCP_GITHUB_TOKEN`, `COPILOT_MCP_ANTHROPIC_API_KEY`), then the standard names (`CURSOR_API_KEY`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, etc.). This allows Copilot sandboxes and standard runners to share the same workflows.
-- Use the environment variable guide’s `env | grep COPILOT_MCP_` and `ai-triage mcp status` checks before manual dispatch to confirm MCP servers and GitHub access resolve correctly.
+- Use the environment variable guide’s `env | grep COPILOT_MCP_` and `agentic-triage mcp status` checks before manual dispatch to confirm MCP servers and GitHub access resolve correctly.
 
 ## Routing to Roadmap and Integration projects
 - **Roadmap ingestion**: `agentic-triage assess` enriches new issues with labels that downstream automation uses to create or update Roadmap project items; `agentic-triage roadmap` can be manually dispatched for targeted backlog generation.


### PR DESCRIPTION
## Summary
- expand Triage Hub guidance on workflow entry points and downstream doc discovery paths across languages
- document MCP-prefixed environment variable precedence and pre-flight checks for triage dispatches
- clarify how assess/review/cascade/roadmap outputs feed Roadmap and Integration project automation

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f35e005e88322b0808d1418149efb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `docs/TRIAGE-HUB.md` describing triage workflow entry points, cross-language doc discovery, MCP env var precedence/checks, and routing to Roadmap/Integration projects.
> 
> - **Documentation**:
>   - **New guide**: `docs/TRIAGE-HUB.md`
>     - **Workflow entry points**: `.github/workflows/triage.yml` running `agentic-triage assess`/`review`; manual `sprint`/`roadmap`/`cascade`/`security` dispatch with repo matrix.
>     - **Documentation discovery**: initialize submodules (`git submodule update --init --recursive`); doc roots for TypeScript (`ecosystems/oss/agentic-control/`, `ecosystems/oss/agentic-triage/`), Python (`ecosystems/oss/agentic-crew/`, `ecosystems/oss/vendor-connectors/`), and Go/Rust; local lookup during CI.
>     - **MCP-aware environment**: precedence per `docs/ENVIRONMENT_VARIABLES.md` (CLI > `COPILOT_MCP_*` > standard vars); pre-flight checks (`env | grep COPILOT_MCP_`, `ai-triage mcp status`).
>     - **Project routing**: how `assess`/`roadmap` feed Roadmap items and `review`/`cascade` supply signals to Integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6030afdeb901fb0bb79405264d92519ecec9f55c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->