### PR TITLE
Improve issue export authentication

### DIFF
--- a/docs/CONTROL-CENTER-ISSUES.md
+++ b/docs/CONTROL-CENTER-ISSUES.md
@@ -8,7 +8,8 @@ flows can ingest and consider them alongside ecosystem tasks.
 
 1. Install the GitHub CLI if it is not already available:
    ```bash
-   sudo apt-get update && sudo apt-get install -y gh
+   # For installation instructions, see the official GitHub CLI documentation:
+   # https://cli.github.com/
    ```
 
 2. Export the issues using a token that can read `jbcom/jbcom-control-center`:

--- a/scripts/export-control-center-issues.sh
+++ b/scripts/export-control-center-issues.sh
@@ -10,6 +10,11 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required (https://stedolan.github.io/jq/)" >&2
+  exit 1
+fi
+
 if [[ -z "${GH_TOKEN_VALUE}" ]]; then
   echo "ERROR: Set GITHUB_JBCOM_TOKEN, GITHUB_TOKEN, or GH_TOKEN to access ${REPO}" >&2
   exit 1


### PR DESCRIPTION
## Summary
- ensure the issue export script requires the GitHub CLI, authenticates with the provided token, and fails fast when prerequisites are missing
- document the GitHub CLI install step and note that the script auto-authenticates the session for paginated issue exports

## Testing
- bash -n scripts/export-control-center-issues.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f3539311883229f970d6ba626af6b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a bash script to export issue snapshots from the control-center repo using GitHub CLI with token auth, plus concise usage docs.
> 
> - **Scripts**:
>   - `scripts/export-control-center-issues.sh`: New export tool that
>     - Requires `gh` and a token (`GITHUB_JBCOM_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`); fails fast if missing.
>     - Auto-authenticates `gh` with the provided token for reliable pagination.
>     - Supports `REPO` override and custom output path; defaults to `jbcom/jbcom-control-center` and `docs/CONTROL-CENTER-ISSUES.md`.
>     - Generates a timestamped markdown snapshot grouping `open` and `closed` issues, excluding pull requests.
> - **Docs**:
>   - `docs/CONTROL-CENTER-ISSUES.md`: Adds playbook with install steps for `gh`, usage of the script, and guidance for integrating snapshots into triage workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 000e991b78c4665065d8f80e5957b347b3cb1555. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->