### PR TITLE
fix: skip LFS during repo sync

### DIFF
--- a/.github/workflows/ecosystem-sync.yml
+++ b/.github/workflows/ecosystem-sync.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Initial file sync (create missing only)
         id: sync
         uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619
+        env:
+          # Skip LFS to avoid issues with repos that have broken LFS objects
+          GIT_LFS_SKIP_SMUDGE: "1"
         with:
           GH_PAT: ${{ secrets.CI_GITHUB_TOKEN }}
           CONFIG_PATH: .github/sync-initial.yml
@@ -128,6 +131,9 @@ jobs:
       - name: Always file sync (overwrite)
         id: sync
         uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619
+        env:
+          # Skip LFS to avoid issues with repos that have broken LFS objects
+          GIT_LFS_SKIP_SMUDGE: "1"
         with:
           GH_PAT: ${{ secrets.CI_GITHUB_TOKEN }}
           CONFIG_PATH: .github/sync-always.yml


### PR DESCRIPTION
Add GIT_LFS_SKIP_SMUDGE=1 to avoid broken LFS object errors in python-ai-game-dev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set GIT_LFS_SKIP_SMUDGE=1 on both sync steps in `.github/workflows/ecosystem-sync.yml` to avoid fetching LFS objects during file sync.
> 
> - **CI Workflow** (`.github/workflows/ecosystem-sync.yml`):
>   - **Phase 1 - Initial Sync**: Add env `GIT_LFS_SKIP_SMUDGE="1"` to `repo-file-sync-action` step.
>   - **Phase 2 - Always Sync**: Add env `GIT_LFS_SKIP_SMUDGE="1"` to `repo-file-sync-action` step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a03f9760eee1963eab583cb80b24821e65049eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->