### PR TITLE
Oss repo sync cleanup

### DIFF
--- a/docs/OSS-REPO-SYNC-CLEANUP.md
+++ b/docs/OSS-REPO-SYNC-CLEANUP.md
@@ -1,0 +1,95 @@
+# OSS Repository Sync Cleanup
+
+**Date**: December 23, 2025  
+**Task**: Clean up sync targets to only include active, public repositories
+
+## Summary
+
+Audited all repositories in `repo-config.json` and removed:
+- **Archived repositories**: 1
+- **Private repositories**: 5
+- **Non-existent repositories with incorrect names**: 1
+
+## Changes Made
+
+### Removed Repositories
+
+| Repository | Reason | Ecosystem |
+|------------|--------|-----------|
+| `python-rivers-of-reckoning` | Archived | Python |
+| `python-terraform-bridge` | Private | Python |
+| `python-ai-game-dev` | Renamed to `python-agentic-game-development` | Python |
+| `nodejs-otter-river-rush` | Private | Node.js |
+| `terraform-github-markdown` | Private | Terraform |
+| `terraform-repository-automation` | Private | Terraform |
+| `.github` | Private (org config repo) | Control |
+
+### Added Repositories
+
+| Repository | Ecosystem |
+|------------|-----------|
+| `rust-cosmic-cults` | Rust (new ecosystem) |
+| `rust-agentic-game-generator` | Rust (new ecosystem) |
+
+### New Ecosystem
+
+Added **Rust ecosystem** with:
+- Sync paths: `always-sync`, `rust`, `initial-only`
+- Ruleset overrides for Clippy linting
+- 2 public repositories
+
+## Final State
+
+**Total Repositories**: 20 (all public and active)
+
+### By Ecosystem
+
+| Ecosystem | Count | Repositories |
+|-----------|-------|--------------|
+| **Python** | 6 | python-agentic-crew, python-vendor-connectors, python-extended-data-types, python-directed-inputs-class, python-lifecyclelogging, python-agentic-game-development |
+| **Node.js** | 9 | nodejs-agentic-control, nodejs-agentic-triage, nodejs-strata, nodejs-strata-capacitor-plugin, nodejs-strata-react-native-plugin, nodejs-strata-examples, nodejs-otterfall, nodejs-rivermarsh, nodejs-pixels-pygame-palace, jbcom.github.io |
+| **Go** | 1 | go-secretsync |
+| **Rust** | 2 | rust-cosmic-cults, rust-agentic-game-generator |
+| **Terraform** | 0 | _(all repos were private - ecosystem kept for future use)_ |
+| **Control** | 1 | control-center |
+
+## Verification
+
+All 20 repositories verified as:
+- ✅ Public visibility
+- ✅ Not archived
+- ✅ Active and accessible
+
+## Notes
+
+### Terraform Ecosystem
+The Terraform ecosystem configuration remains in place but has no active public repositories. This is intentional to:
+1. Maintain the structure for future public Terraform repositories
+2. Keep the sync configuration and ruleset definitions available
+3. Avoid breaking the configuration structure
+
+### Rust Ecosystem
+Created new Rust ecosystem with:
+- Language-specific rules at `repository-files/rust/.cursor/rules/rust.mdc`
+- Clippy linting integration in PR rulesets
+- Standard documentation structure
+
+## Next Steps
+
+1. ✅ Configuration updated in `repo-config.json`
+2. ⏭️ Next sync will only target these 20 public repositories
+3. ⏭️ Monitor for new public repositories to add
+4. ⏭️ Consider making private repos public if appropriate
+
+## Command Used
+
+```bash
+export GITHUB_TOKEN=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
+gh repo list jbcom --limit 100 --json name,isArchived,visibility
+```
+
+## Configuration File
+
+Updated: `/workspace/repo-config.json`
+
+All changes documented with comments in the configuration file using `_comment_removed_repos` fields.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,66 @@
 # Active Context - jbcom Control Center
 
-## Current Status: DOCUMENTATION BRANDING STANDARDIZED
+## Current Status: OSS REPOSITORY SYNC CLEANUP COMPLETE
+
+Cleaned up all sync targets to only include active, public repositories. Removed archived and private repos from sync configuration.
+
+---
+
+## Session: 2025-12-23 (OSS Repository Sync Cleanup)
+
+### Task
+Audit all repositories in sync configuration and ensure we're only syncing to active, non-archived, PUBLIC repositories.
+
+### Changes Made
+
+**Removed Repositories (7 total):**
+- `python-rivers-of-reckoning` - ARCHIVED
+- `python-terraform-bridge` - PRIVATE
+- `python-ai-game-dev` - Renamed to `python-agentic-game-development`
+- `nodejs-otter-river-rush` - PRIVATE
+- `terraform-github-markdown` - PRIVATE
+- `terraform-repository-automation` - PRIVATE
+- `.github` - PRIVATE (org config repo)
+
+**Added Repositories (2 total):**
+- `rust-cosmic-cults` - PUBLIC, active
+- `rust-agentic-game-generator` - PUBLIC, active
+
+**New Ecosystem Created:**
+- Added Rust ecosystem with Clippy linting rules
+- Configured at `repository-files/rust/`
+
+### Final State
+
+✅ **20 active public repositories** configured for sync
+
+| Ecosystem | Count | Status |
+|-----------|-------|--------|
+| Python | 6 | All public & active |
+| Node.js | 9 | All public & active |
+| Go | 1 | All public & active |
+| Rust | 2 | All public & active |
+| Terraform | 0 | Empty (repos were private) |
+| Control | 1 | All public & active |
+
+### Files Changed
+- `repo-config.json` - Updated with removal comments
+- `docs/OSS-REPO-SYNC-CLEANUP.md` - Full cleanup report
+
+### Verification
+All 20 repositories verified as:
+- ✅ Public visibility
+- ✅ Not archived
+- ✅ Accessible via GitHub API
+
+### For Next Agent
+- Next sync will only target these 20 verified public repositories
+- Monitor for new public repos to add
+- Terraform ecosystem structure maintained for future use
+
+---
+
+## Previous Status: DOCUMENTATION BRANDING STANDARDIZED
 
 Added unified jbcom Design System to always-sync for brand consistency across ALL repositories.
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,61 @@
 # Session Progress Log
 
+## Session: 2025-12-23 (OSS Repository Sync Cleanup)
+
+### What Was Done
+
+1. **Audited All Public Repositories**
+   - Used GitHub API to list all public jbcom repos
+   - Cross-referenced with `repo-config.json` configuration
+   - Identified archived and private repos in sync targets
+
+2. **Removed Non-Public Repositories**
+   - 1 archived repo: `python-rivers-of-reckoning`
+   - 5 private repos: `python-terraform-bridge`, `nodejs-otter-river-rush`, `terraform-github-markdown`, `terraform-repository-automation`, `.github`
+   - 1 renamed repo: `python-ai-game-dev` → `python-agentic-game-development`
+
+3. **Added Missing Public Repositories**
+   - `rust-cosmic-cults` (new Rust ecosystem)
+   - `rust-agentic-game-generator` (new Rust ecosystem)
+
+4. **Created Rust Ecosystem**
+   - Added ecosystem configuration with Clippy linting
+   - Rust rules already exist at `repository-files/rust/`
+   - Configured PR rulesets with CodeQL and Clippy analysis
+
+5. **Documentation**
+   - Created `docs/OSS-REPO-SYNC-CLEANUP.md` with full audit report
+   - Updated `memory-bank/activeContext.md` with session summary
+   - Added removal comments to `repo-config.json`
+
+### Final State
+
+| Metric | Count |
+|--------|-------|
+| Total Public Active Repos | 20 |
+| Removed from Sync | 7 |
+| Added to Sync | 2 |
+| Ecosystems | 6 (Python, Node.js, Go, Terraform, Rust, Control) |
+
+**All 20 configured repositories verified as:**
+- ✅ Public visibility
+- ✅ Not archived
+- ✅ Active and accessible
+
+### Key Findings
+
+- **Terraform ecosystem**: Now empty (both repos were private), but structure kept for future use
+- **Rust ecosystem**: New addition with 2 active game development repos
+- **Private repos excluded**: Sync only targets public OSS repositories per requirements
+
+### Files Changed
+
+- `repo-config.json` - Updated ecosystem configurations
+- `docs/OSS-REPO-SYNC-CLEANUP.md` - Complete audit report
+- `memory-bank/activeContext.md` - Session summary
+
+---
+
 ## Session: 2025-12-16 (jbdevprimary → jbcom Migration)
 
 ### What Was Done

--- a/repo-config.json
+++ b/repo-config.json
@@ -203,10 +203,9 @@
         "python-extended-data-types",
         "python-directed-inputs-class",
         "python-lifecyclelogging",
-        "python-terraform-bridge",
-        "python-rivers-of-reckoning",
-        "python-ai-game-dev"
+        "python-agentic-game-development"
       ],
+      "_comment_removed_repos": "python-rivers-of-reckoning (archived), python-terraform-bridge (private), python-ai-game-dev (renamed to python-agentic-game-development)",
       "ruleset_overrides": {
         "prs": {
           "rules": [
@@ -248,12 +247,12 @@
         "nodejs-strata-capacitor-plugin",
         "nodejs-strata-react-native-plugin",
         "nodejs-strata-examples",
-        "nodejs-otter-river-rush",
         "nodejs-otterfall",
         "nodejs-rivermarsh",
         "nodejs-pixels-pygame-palace",
         "jbcom.github.io"
-      ]
+      ],
+      "_comment_removed_repos": "nodejs-otter-river-rush removed - private repo"
     },
     "go": {
       "files": {
@@ -298,13 +297,49 @@
         "always": ["always-sync", "terraform"],
         "initial": ["initial-only"]
       },
-      "repos": [
-        "terraform-github-markdown",
-        "terraform-repository-automation"
-      ],
+      "repos": [],
+      "_comment_removed_repos": "terraform-github-markdown and terraform-repository-automation removed - both private repos",
       "feature_overrides": {
         "has_pages": false,
         "has_discussions": false
+      }
+    },
+    "rust": {
+      "files": {
+        "always": ["always-sync", "rust"],
+        "initial": ["initial-only"]
+      },
+      "repos": [
+        "rust-cosmic-cults",
+        "rust-agentic-game-generator"
+      ],
+      "ruleset_overrides": {
+        "prs": {
+          "rules": [
+            {
+              "type": "copilot_code_review",
+              "parameters": {
+                "review_draft_pull_requests": false,
+                "review_on_push": true
+              }
+            },
+            {
+              "type": "copilot_code_review_analysis_tools",
+              "parameters": {
+                "tools": [
+                  { "name": "CodeQL" },
+                  { "name": "Clippy" }
+                ]
+              }
+            },
+            {
+              "type": "code_quality",
+              "parameters": {
+                "severity": "errors"
+              }
+            }
+          ]
+        }
       }
     },
     "control": {
@@ -313,10 +348,9 @@
         "initial": []
       },
       "repos": [
-        "control-center",
-        ".github"
+        "control-center"
       ],
-      "_comment": "Control center and org config - no file sync, just project tracking"
+      "_comment": "Control center (public) - no file sync, just project tracking. .github removed (private org config repo)"
     }
   }
 }


### PR DESCRIPTION
Clean up `repo-config.json` sync targets to include only active, non-archived, public OSS repositories.

This PR removes 7 non-compliant repositories (archived, private, or renamed) and adds 2 new public Rust repositories, establishing a new Rust ecosystem for sync.

---
<a href="https://cursor.com/background-agent?bcId=bc-26874c15-77cd-4968-8993-ab38fe4ed07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26874c15-77cd-4968-8993-ab38fe4ed07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns sync targets to active, public repositories and introduces a Rust ecosystem.
> 
> - Updates `repo-config.json`: removes 7 non-public repos, replaces `python-ai-game-dev` with `python-agentic-game-development`, adds `_comment_removed_repos`, keeps Terraform ecosystem but empties its `repos` list
> - Adds Rust ecosystem: sync paths (`always-sync`, `rust`, `initial-only`), PR rules with CodeQL+Clippy, and 2 repos (`rust-cosmic-cults`, `rust-agentic-game-generator`)
> - Updates documentation and context: adds `docs/OSS-REPO-SYNC-CLEANUP.md` report and refreshes `memory-bank/activeContext.md` and `progress.md`
> - Result: 20 public, active repositories across Python, Node.js, Go, Rust, and Control
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7c5071d8ee6e9d53f639f4d17fa1e9be6e72917. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->