### PR TITLE
feat(config): add arcade-cabinet organization and rivers-of-reckoning repo

### DIFF
--- a/repo-config.json
+++ b/repo-config.json
@@ -555,6 +555,21 @@
         "logging",
         "core"
       ]
+    },
+    "arcade-cabinet": {
+      "organization": "arcade-cabinet",
+      "files": {
+        "always": [
+          "always-sync",
+          "python"
+        ],
+        "initial": [
+          "initial-only"
+        ]
+      },
+      "repos": [
+        "rivers-of-reckoning"
+      ]
     }
   },
   "organizations": {
@@ -563,13 +578,15 @@
       "jbcom",
       "strata-game-library",
       "agentic-dev-library",
-      "extended-data-library"
+      "extended-data-library",
+      "arcade-cabinet"
     ],
     "domains": {
       "jbcom": "jonbogaty.com",
       "strata-game-library": "strata.game",
       "agentic-dev-library": "agentic.dev",
-      "extended-data-library": "extendeddata.dev"
+      "extended-data-library": "extendeddata.dev",
+      "arcade-cabinet": "arcade-cabinet.org"
     }
   }
 }


### PR DESCRIPTION
Adds the new arcade-cabinet organization to the managed organizations list and includes rivers-of-reckoning in the python ecosystem sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new ecosystem and updates org management to include it.
> 
> - Introduces `ecosystems.arcade-cabinet` (org: `arcade-cabinet`) with file sync settings (`always-sync`, `python`) and repo `rivers-of-reckoning`
> - Updates `organizations.managed` to include `arcade-cabinet` and adds domain mapping `arcade-cabinet: arcade-cabinet.org`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2beb473e8fe40f1589417b1f85b810d86d614b6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->