### PR TITLE
fix(sync): explicitly export GH_TOKEN in create-repos

### DIFF
--- a/repo-config.json
+++ b/repo-config.json
@@ -375,12 +375,12 @@
         ]
       },
       "repos": [
+        "jbcom.github.io",
         "nodejs-agentic-control",
         "nodejs-agentic-triage",
         "nodejs-otterfall",
-        "nodejs-rivermarsh",
         "nodejs-pixels-pygame-palace",
-        "jbcom.github.io"
+        "nodejs-rivermarsh"
       ],
       "repo_overrides": {
         "nodejs-agentic-triage": {

--- a/scripts/create-repos
+++ b/scripts/create-repos
@@ -154,9 +154,12 @@ main() {
   
   # Ensure GH_TOKEN is set for gh auth status to work in CI
   if [[ -z "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
-     log_error "No GitHub token found in GH_TOKEN or GITHUB_TOKEN environment variables."
-     exit 1
+    log_error "No GitHub token found in GH_TOKEN or GITHUB_TOKEN environment variables."
+    exit 1
   fi
+  # For CI environments, we may need to set the token explicitly for the current process
+  export GH_TOKEN="${GH_TOKEN:-$GITHUB_TOKEN}"
+
   # For CI environments, we may need to set the token explicitly for the current process
   export GH_TOKEN="${GH_TOKEN:-$GITHUB_TOKEN}"
 


### PR DESCRIPTION
Ensures the GH_TOKEN is exported for the GitHub CLI to recognize it in the CI environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope:** CI workflow token update and repo creation script enhancements.
> 
> - Replace `CI_GITHUB_TOKEN` with `JBCOM_TOKEN` across `ecosystem-sync.yml` (create repos, initial/always sync, project sync) and update troubleshooting note
> - Refactor `scripts/create-repos` to be org-aware: read organization per ecosystem from `repo-config.json` (default `jbcom`), pass `org` to `repo_exists`/`create_repo`, and adjust logging
> - Add robust auth handling in `create-repos`: require `GH_TOKEN`/`GITHUB_TOKEN`, export `GH_TOKEN`, and improve error messaging for `gh auth status`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 476b4f41e982951b82652044184673679b2100c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->