### PR TITLE
fix(harvester): add 'copilot' to bot authors for auto-merge

### DIFF
--- a/scripts/ecosystem-curator.mjs
+++ b/scripts/ecosystem-curator.mjs
@@ -26,10 +26,11 @@ const TARGET_ORG = process.env.TARGET_ORG;
 const TARGET_REPO = process.env.TARGET_REPO;
 
 // Bot authors - auto-merge without human approval
+// Case-insensitive matching is used - see processPR()
 const BOT_AUTHORS = [
   'google-labs-jules',
   'copilot-swe-agent',
-  'copilot',  // GitHub Copilot workspace agent
+  'Copilot',  // GitHub Copilot workspace agent
   'dependabot',
   'renovate',
   'github-actions',

--- a/scripts/ecosystem-harvester.mjs
+++ b/scripts/ecosystem-harvester.mjs
@@ -22,10 +22,11 @@ const GOOGLE_JULES_API_KEY = process.env.GOOGLE_JULES_API_KEY;
 const DRY_RUN = process.env.DRY_RUN === 'true';
 
 // Bot authors that get auto-merge treatment (no human approval needed)
+// Case-insensitive matching is used - see processPR()
 const BOT_AUTHORS = [
   'google-labs-jules',
   'copilot-swe-agent',
-  'copilot',  // GitHub Copilot workspace agent
+  'Copilot',  // GitHub Copilot workspace agent
   'dependabot',
   'renovate',
   'github-actions',
@@ -321,7 +322,8 @@ async function processPRs() {
 async function processPR(owner, repo, pr) {
   stats.prs_reviewed++;
   const prAuthor = pr.user?.login || '';
-  const isBotPR = BOT_AUTHORS.some(bot => prAuthor.includes(bot.replace('[bot]', '')));
+  const prAuthorLower = prAuthor.toLowerCase();
+  const isBotPR = BOT_AUTHORS.some(bot => prAuthorLower.includes(bot.replace('[bot]', '').toLowerCase()));
   
   console.log(`   ${owner}/${repo}#${pr.number}: ${pr.title.substring(0, 50)}...`);
   console.log(`     Author: ${prAuthor} (bot: ${isBotPR})`);


### PR DESCRIPTION
## Summary

GitHub Copilot workspace agent uses 'Copilot' as its login, not 'copilot-swe-agent'. This fix adds 'copilot' to the bot authors list so these PRs get auto-merge treatment.

## Changes

- Added `'copilot'` to `BOT_AUTHORS` in `ecosystem-harvester.mjs`
- Added `'copilot'` to `BOT_AUTHORS` in `ecosystem-curator.mjs`

## Test Plan

- [ ] Verify harvester detects Copilot PRs as bot PRs
- [ ] Verify auto-merge works for Copilot PRs with passing CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures PRs authored by GitHub Copilot are recognized as bot PRs and eligible for auto-merge when checks pass.
> 
> - Adds `"copilot"` to `BOT_AUTHORS` in `scripts/ecosystem-harvester.mjs` and `scripts/ecosystem-curator.mjs`
> - Minor formatting cleanup in bot authors arrays
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b182d9d4b11d09d3208822c5072645f2b7dd8d83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->