### PR TITLE
Wire Otter River Rush to Control Center

### DIFF
--- a/repo-config.json
+++ b/repo-config.json
@@ -280,7 +280,8 @@
     "strata-game-library/presets": "Preset configurations for Strata 3D - ready-to-use terrain, water, sky, and effect presets",
     "strata-game-library/typescript-tutor": "Professor Pixels educational game platform - interactive lessons for learning game development",
     "strata-game-library/capacitor-plugin": "Capacitor plugin for Strata 3D - cross-platform input, device detection, and haptics for mobile games",
-    "strata-game-library/react-native-plugin": "React Native plugin for Strata 3D - cross-platform input, device detection, and haptics for mobile games"
+    "strata-game-library/react-native-plugin": "React Native plugin for Strata 3D - cross-platform input, device detection, and haptics for mobile games",
+    "arcade-cabinet/otter-river-rush": "High-performance 3D infinite runner game built with React Three Fiber and Miniplex ECS"
   },
   "domains": {
     "strata.game": {
@@ -579,14 +580,15 @@
       "files": {
         "always": [
           "always-sync",
-          "python"
+          "nodejs"
         ],
         "initial": [
           "initial-only"
         ]
       },
       "repos": [
-        "rivers-of-reckoning"
+        "rivers-of-reckoning",
+        "otter-river-rush"
       ]
     }
   },


### PR DESCRIPTION
Adds arcade-cabinet/otter-river-rush to the managed repositories and ecosystems.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates the new `arcade-cabinet/otter-river-rush` repo into configuration and aligns arcade-cabinet with Node.js tooling.
> 
> - Adds repository description for `arcade-cabinet/otter-river-rush`
> - Includes `otter-river-rush` in arcade-cabinet ecosystem `repos`
> - Changes arcade-cabinet ecosystem `files.always` from `python` to `nodejs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9080dc8bee0e6574a54211bac6715fa5ea3e69c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->