### PR TITLE
fix: use compact JSON output for GITHUB_OUTPUT in surveyor

### DIFF
--- a/.github/workflows/ecosystem-surveyor.yml
+++ b/.github/workflows/ecosystem-surveyor.yml
@@ -74,7 +74,7 @@ jobs:
             CONTROL_CENTER=$(jq -r --arg org "$ORG" '.managedOrganizations[] | select(.org == $org) | .controlCenter' .github/org-registry.json)
             
             if gh repo view "$CONTROL_CENTER" > /dev/null 2>&1; then
-              ORGS=$(echo "$ORGS" | jq --arg org "$ORG" '. + [$org]')
+              ORGS=$(echo "$ORGS" | jq -c --arg org "$ORG" '. + [$org]')
               echo "  ✅ $CONTROL_CENTER"
             else
               echo "  ⚠️ $CONTROL_CENTER not found or not accessible"
@@ -83,10 +83,11 @@ jobs:
           
           # Filter if specific org requested
           if [ -n "${{ inputs.target_org }}" ]; then
-            ORGS=$(echo "$ORGS" | jq --arg org "${{ inputs.target_org }}" '[.[] | select(. == $org)]')
+            ORGS=$(echo "$ORGS" | jq -c --arg org "${{ inputs.target_org }}" '[.[] | select(. == $org)]')
           fi
           
-          echo "orgs=$ORGS" >> $GITHUB_OUTPUT
+          # Output compact JSON (single line) for GITHUB_OUTPUT
+          echo "orgs=$(echo "$ORGS" | jq -c '.')" >> $GITHUB_OUTPUT
           echo ""
           echo "📋 Will sync to: $ORGS"
 

--- a/repository-files/always-sync/.github/workflows/ecosystem-surveyor.yml
+++ b/repository-files/always-sync/.github/workflows/ecosystem-surveyor.yml
@@ -74,7 +74,7 @@ jobs:
             CONTROL_CENTER=$(jq -r --arg org "$ORG" '.managedOrganizations[] | select(.org == $org) | .controlCenter' .github/org-registry.json)
             
             if gh repo view "$CONTROL_CENTER" > /dev/null 2>&1; then
-              ORGS=$(echo "$ORGS" | jq --arg org "$ORG" '. + [$org]')
+              ORGS=$(echo "$ORGS" | jq -c --arg org "$ORG" '. + [$org]')
               echo "  ✅ $CONTROL_CENTER"
             else
               echo "  ⚠️ $CONTROL_CENTER not found or not accessible"
@@ -83,10 +83,11 @@ jobs:
           
           # Filter if specific org requested
           if [ -n "${{ inputs.target_org }}" ]; then
-            ORGS=$(echo "$ORGS" | jq --arg org "${{ inputs.target_org }}" '[.[] | select(. == $org)]')
+            ORGS=$(echo "$ORGS" | jq -c --arg org "${{ inputs.target_org }}" '[.[] | select(. == $org)]')
           fi
           
-          echo "orgs=$ORGS" >> $GITHUB_OUTPUT
+          # Output compact JSON (single line) for GITHUB_OUTPUT
+          echo "orgs=$(echo "$ORGS" | jq -c '.')" >> $GITHUB_OUTPUT
           echo ""
           echo "📋 Will sync to: $ORGS"
 


### PR DESCRIPTION
## Summary

The orgs array was being output with newlines which broke GITHUB_OUTPUT format.

## Changes

- Use `jq -c` to ensure compact single-line JSON output
- Fixes the Ecosystem Surveyor workflow failure after merge

## Root Cause

When outputting JSON arrays to `$GITHUB_OUTPUT`, GitHub expects values on a single line. The previous code was outputting pretty-printed JSON with newlines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the `orgs` matrix is emitted as compact, single-line JSON to fix parsing in GitHub Actions.
> 
> - Use `jq -c` when building and filtering `ORGS` to avoid pretty-printed arrays
> - Write compact JSON to `$GITHUB_OUTPUT` via `echo "orgs=$(echo "$ORGS" | jq -c '.')"` with clarifying comment
> - Apply the same fixes to the mirrored workflow under `repository-files/always-sync/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1108f40d7bd6b60f8a8474aeb35e8f241e062efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->