### PR TITLE
fix(release): add GoReleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,87 @@
+# GoReleaser configuration for control-center
+# https://goreleaser.com
+version: 2
+
+project_name: control-center
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+
+builds:
+  - id: control-center
+    main: ./cmd/control-center
+    binary: control-center
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: jbcom
+    name: control-center
+  draft: false
+  prerelease: auto
+  header: |
+    ## control-center {{ .Tag }}
+    
+    Enterprise AI orchestration for the jbcom ecosystem.
+    
+    ### Installation
+    
+    **Go:**
+    ```bash
+    go install github.com/jbcom/control-center/cmd/control-center@{{ .Version }}
+    ```
+    
+    **Docker:**
+    ```bash
+    docker pull ghcr.io/jbcom/control-center:{{ .Version }}
+    ```
+    
+    **Binary:**
+    Download from the assets below for your platform.
+    
+    **GitHub Action:**
+    ```yaml
+    - uses: jbcom/control-center@{{ .Tag }}
+      with:
+        command: reviewer
+        repo: owner/repo
+        pr: 123
+    ```


### PR DESCRIPTION
## Summary
- Adds `.goreleaser.yaml` configuration file
- Fixes template error in release body (was using GitHub Actions syntax instead of Go template syntax)

## Test Plan
- [x] GoReleaser config is valid YAML
- [ ] Re-run release after merge

Fixes the failed v0.1.0 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up automated releases via GoReleaser.
> 
> - Adds `.goreleaser.yaml` to build `control-center` for linux/darwin/windows on `amd64` and `arm64` with version `ldflags`
> - Produces platform-specific archives (zip for Windows) and a `sha256` `checksums.txt`
> - Uses GitHub changelog generation with basic filters
> - Configures GitHub release (owner/name), draft/prerelease behavior, and a templated release header with install instructions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1abd9153c4d5e93a3898f114c3f2920f9025ed62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->