### PR TITLE
Enterprise sync and bootstrap

### DIFF
--- a/.github/org-registry.json
+++ b/.github/org-registry.json
@@ -60,6 +60,17 @@
         "include": "*",
         "exclude": []
       }
+    },
+    {
+      "org": "arcade-cabinet",
+      "domain": "arcade-cabinet.org",
+      "controlCenter": "arcade-cabinet/control-center",
+      "languages": ["typescript", "python", "rust"],
+      "focus": ["Indie games", "Arcade experiences", "Game development"],
+      "repoFilter": {
+        "include": "*",
+        "exclude": []
+      }
     }
   ],
   

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
 
+version: "2"
+
 linters:
   enable:
     - errcheck      # Check for unchecked errors

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,5 +1,36 @@
 # Active Context
 
+## Session: 2025-12-31 (Enterprise Cascade & Otterblade Bootstrap)
+
+### Completed
+- [x] Verified GitHub token has all required scopes (admin:org, repo, workflow, etc.)
+- [x] Added arcade-cabinet to org-registry.json as managed organization
+- [x] Added otterblade-odyssey and other arcade repos to repo-config.json
+- [x] Triggered jbcom-gardener workflow targeting arcade-cabinet
+- [x] Triggered arcade-cabinet/control-center sync workflow
+- [x] Bootstrapped otterblade-odyssey with enterprise cursor rules and AI workflows
+- [x] Verified all 4 org control centers exist and sync successfully:
+  - arcade-cabinet/control-center ✅
+  - agentic-dev-library/control-center ✅
+  - strata-game-library/control-center ✅
+  - extended-data-library/control-center ✅
+- [x] Fixed golangci-lint config (added missing version field)
+
+### Current State
+- Enterprise cascade is operational across all 4 organizations
+- otterblade-odyssey now has:
+  - `.cursor/rules/` (fundamentals, pr-workflow, memory-bank, etc.)
+  - 19 AI/ecosystem workflows (ai-reviewer, ai-fixer, jules-supervisor, etc.)
+- Go workflow failing on lint config version - now fixed
+- Token scopes verified for cross-org operations
+
+### For Next Agent
+- Commit and push these configuration changes
+- Verify CI passes after golangci-lint fix
+- Consider adding more arcade-cabinet repos to the sync list if needed
+
+---
+
 ## Session: 2025-12-31 (Full Release & Cascade Verification)
 
 ### Completed

--- a/repo-config.json
+++ b/repo-config.json
@@ -597,7 +597,16 @@
       },
       "repos": [
         "otter-river-rush",
-        "rivers-of-reckoning"
+        "rivers-of-reckoning",
+        "otterblade-odyssey",
+        "otter-elite-force",
+        "ebb-and-bloom",
+        "realm-walker",
+        "protocol-silent-night",
+        "rivermarsh",
+        "dragons-labyrinth",
+        "echoes-of-beastlight",
+        "cosmic-cults"
       ]
     }
   },


### PR DESCRIPTION
Add `arcade-cabinet` organization and `otterblade-odyssey` repo to enable enterprise-level bootstrapping and fix Go CLI linting.

The `arcade-cabinet` organization was not previously managed by the enterprise control center, preventing `otterblade-odyssey` from being automatically bootstrapped with standard cursor rules and workflows. This PR integrates the organization and its new game repo into the enterprise cascade. Additionally, the Go CLI tool's `golangci-lint` configuration was missing a `version` field, causing linting failures, which has been corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4a4fe02-db1f-42e1-9607-89fc57f86307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4a4fe02-db1f-42e1-9607-89fc57f86307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

